### PR TITLE
prefer IANA MIME for .ico

### DIFF
--- a/db.json
+++ b/db.json
@@ -5309,7 +5309,9 @@
     "source": "iana"
   },
   "image/vnd.microsoft.icon": {
-    "source": "iana"
+    "source": "iana",
+    "compressible": true,
+    "extensions": ["ico"]
   },
   "image/vnd.mix": {
     "source": "iana"
@@ -5385,9 +5387,7 @@
     "extensions": ["fh","fhc","fh4","fh5","fh7"]
   },
   "image/x-icon": {
-    "source": "apache",
-    "compressible": true,
-    "extensions": ["ico"]
+    "source": "apache"
   },
   "image/x-mrsid-image": {
     "source": "apache",


### PR DESCRIPTION
`image/x-icon` is not a valid MIME type according to the IANA database.
the correct MIME type for .ico files is `image/vnd.microsoft.icon`