### PR TITLE
Adding hjson and json5 mime types.

### DIFF
--- a/lib/extensions.json
+++ b/lib/extensions.json
@@ -29,5 +29,8 @@
   ],
   "text/hjson": [
     "hjson"
+  ],
+  "application/json5": [
+    "json5"
   ]
 }


### PR DESCRIPTION
I have been using this relatively new superset of JSON which I find to be a really nice middle ground between JSON and YAML. It reduces the effort of building objects and anyone who understands JSON can transition to. YAML tends to throw a wrench in the works when it needs to be edited outside of something like vim.

https://github.com/laktak/hjson

I'd love to get it in here so that I can give `mime-type` a go.
