### PR TITLE
fix missing application/ld+json extension

### DIFF
--- a/src/custom.json
+++ b/src/custom.json
@@ -59,6 +59,9 @@
   "application/json5": {
     "extensions": ["json5"]
   },
+  "application/ld+json": {
+    "extensions": ["jsonld"]
+  },
   "application/mp4": {
     "extensions": ["m4p"]
   },


### PR DESCRIPTION
This adds the `jsonld` extension to mime type "application/ld+json". See: http://www.iana.org/assignments/media-types/application/ld+json.