### PR TITLE
add info to text/rtf

### DIFF
--- a/src/custom.json
+++ b/src/custom.json
@@ -516,6 +516,10 @@
   "text/richtext": {
     "compressible": true
   },
+  "text/rtf": {
+    "compressible": true,
+    "extensions": ["rtf"]
+  },
   "text/stylus": {
     "extensions": ["stylus","styl"]
   },


### PR DESCRIPTION
Note: sorry couldn't run npm run update
installed gnode globally (as it was not found) then got module 'ms' not found - installed ms globally - but ms still not found - using the latest IO.js