### PR TITLE
Add processing mime type

### DIFF
--- a/src/custom-types.json
+++ b/src/custom-types.json
@@ -515,6 +515,13 @@
     "compressible": true,
     "extensions": ["ini"]
   },
+  "text/x-processing": {
+    "compressible": true,
+    "extensions": ["pde"],
+    "sources": [
+      "https://en.wikipedia.org/wiki/Processing_(programming_language)"
+    ]
+  },
   "text/richtext": {
     "compressible": true
   },


### PR DESCRIPTION
Hi! I realised that Processing IDE extension is not in the database and I would like to add it.

Hope it helps!
Cheers!