### PR TITLE
Update informations for JS and PHP types

### DIFF
--- a/db.json
+++ b/db.json
@@ -4298,6 +4298,10 @@
     "source": "apache",
     "extensions": ["hdf"]
   },
+  "application/x-httpd-php": {
+    "compressible": true,
+    "extensions": ["php"]
+  },
   "application/x-install-instructions": {
     "source": "apache",
     "extensions": ["install"]
@@ -5795,7 +5799,8 @@
   },
   "text/javascript": {
     "source": "iana",
-    "compressible": true
+    "compressible": true,
+    "extensions": ["js"]
   },
   "text/jcr-cnd": {
     "source": "iana"
@@ -5827,6 +5832,10 @@
   },
   "text/parityfec": {
     "source": "iana"
+  },
+  "text/php": {
+    "compressible": true,
+    "extensions": ["php"]
   },
   "text/plain": {
     "source": "iana",
@@ -6059,6 +6068,10 @@
   "text/x-pascal": {
     "source": "apache",
     "extensions": ["p","pas"]
+  },
+  "text/x-php": {
+    "compressible": true,
+    "extensions": ["php"]
   },
   "text/x-processing": {
     "compressible": true,

--- a/src/custom-types.json
+++ b/src/custom-types.json
@@ -230,6 +230,10 @@
       "http://www.phpied.com/gzip-your-font-face-files/"
     ]
   },
+  "application/x-httpd-php": {
+    "compressible": true,
+    "extensions": ["php"]
+  },
   "application/x-java-jnlp-file": {
     "compressible": false
   },
@@ -493,7 +497,8 @@
     "extensions": ["jade"]
   },
   "text/javascript": {
-    "compressible": true
+    "compressible": true,
+    "extensions": ["js"]
   },
   "text/jsx": {
     "compressible": true,
@@ -510,6 +515,10 @@
     "sources": [
       "http://en.wikipedia.org/wiki/Notation3"
     ]
+  },
+  "text/php": {
+    "compressible": true,
+    "extensions": ["php"]
   },
   "text/plain": {
     "compressible": true,
@@ -557,6 +566,10 @@
   "text/x-markdown": {
     "compressible": true,
     "extensions": ["markdown","md","mkd"]
+  },
+  "text/x-php": {
+    "compressible": true,
+    "extensions": ["php"]
   },
   "text/x-processing": {
     "compressible": true,

--- a/src/iana-types.json
+++ b/src/iana-types.json
@@ -188,7 +188,8 @@
   },
   "application/cals-1840": {
     "sources": [
-      "http://tools.ietf.org/rfc/rfc1895.txt"
+      "http://tools.ietf.org/rfc/rfc1895.txt",
+      "http://www.iana.org/assignments/media-types/application/CALS-1840"
     ]
   },
   "application/cbor": {


### PR DESCRIPTION
- `text/javascript` should have `js` extension
- Add `text/php` for CodeMirror