### PR TITLE
Add Apple Passbook .pkpass type

### DIFF
--- a/db.json
+++ b/db.json
@@ -1311,6 +1311,10 @@
     "source": "iana",
     "extensions": ["m3u8"]
   },
+  "application/vnd.apple.pkpass": {
+    "compressible": false,
+    "extensions": ["pkpass"]
+  },
   "application/vnd.arastra.swi": {
     "source": "iana"
   },

--- a/src/custom-types.json
+++ b/src/custom-types.json
@@ -128,6 +128,13 @@
   "application/vnd.android.package-archive": {
     "compressible": false
   },
+  "application/vnd.apple.pkpass": {
+    "compressible": false,
+    "extensions": ["pkpass"],
+    "sources": [
+      "https://developer.apple.com/library/ios/documentation/UserExperience/Conceptual/PassKit_PG/Chapters/Creating.html"
+    ]
+  },
   "application/vnd.dart": {
     "compressible": true
   },


### PR DESCRIPTION
This change adds the `application/vnd.apple.pkpass` Type which is required by Apple when delivering Passbook `.pkpass` files. [See Apple Documentation here](https://developer.apple.com/library/ios/documentation/UserExperience/Conceptual/PassKit_PG/Chapters/Creating.html#//apple_ref/doc/uid/TP40012195-CH4-SW56)