### PR TITLE
Use "jpg" as the first extension of "image/jpeg"

### DIFF
--- a/db.json
+++ b/db.json
@@ -5413,7 +5413,7 @@
   "image/jpeg": {
     "source": "iana",
     "compressible": false,
-    "extensions": ["jpeg","jpg","jpe"]
+    "extensions": ["jpg","jpeg","jpe"]
   },
   "image/jpm": {
     "source": "iana"


### PR DESCRIPTION
Usually, we prefer to use `jpg` as the extension instead of `jpeg`.

For Example:

```js
// ...
var contentType = req.headers['content-type']; // => 'image/jpeg'
var data = db[contentType];
if (data) {
    var ext = data['extensions'][0]; // => 'jpg'
    req.pipe(fs.createWriteStream(filename + '.' + ext));
}
// ...
```