### PR TITLE
A new MIME type (application/package .pak) for Firefox OS new security module

### DIFF
--- a/src/custom-types.json
+++ b/src/custom-types.json
@@ -95,6 +95,9 @@
   "application/ogg": {
     "compressible": false
   },
+  "application/package": {
+    "extensions": ["pak"]
+  },
   "application/pdf": {
     "compressible": false
   },


### PR DESCRIPTION
To my knowledge, the list of Github supported MIME types is generated from the mime-db project.
We're developing a new security module on Firefox OS. I was wondering if we can add the MIME type - "application/package .pak" to the database.

Thank you. Have a nice day.