### PR TITLE
add rng extension (Relax-NG XML)

### DIFF
--- a/src/custom-types.json
+++ b/src/custom-types.json
@@ -329,7 +329,10 @@
   },
   "application/xml": {
     "compressible": true,
-    "extensions": ["xsd"]
+    "extensions": ["xsd", "rng"],
+    "sources": [
+      "http://en.wikipedia.org/wiki/RELAX_NG"
+    ]
   },
   "application/xml-dtd": {
     "compressible": true,


### PR DESCRIPTION
rng is the common extension for Relax-NG in XML, http://en.wikipedia.org/wiki/RELAX_NG

* xsd is already registred (another XML schema language)
* rnc, the Relax-NG Compact syntax is also registred, by Apache (https://github.com/jshttp/mime-db/blob/master/src/apache-types.json#L337)

Correct mime-type is better for validation against schema online.