### PR TITLE
Add .pug extension to text/jade mime type

### DIFF
--- a/src/custom-types.json
+++ b/src/custom-types.json
@@ -539,7 +539,7 @@
     "compressible": true
   },
   "text/jade": {
-    "extensions": ["jade"]
+    "extensions": ["jade", "pug"]
   },
   "text/javascript": {
     "compressible": true


### PR DESCRIPTION
Jade has been renamed to Pug since commit 355d3da.