### PR TITLE
Add audio/mp3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@
 
 node_modules
 coverage
+
+.idea

--- a/db.json
+++ b/db.json
@@ -5062,6 +5062,10 @@
   "audio/mobile-xmf": {
     "source": "iana"
   },
+  "audio/mp3": {
+    "compressible": false,
+    "extensions": ["mp3"]
+  },
   "audio/mp4": {
     "source": "iana",
     "compressible": false,

--- a/src/custom-types.json
+++ b/src/custom-types.json
@@ -359,6 +359,14 @@
   "audio/basic": {
     "compressible": false
   },
+  "audio/mp3": {
+    "compressible": false,
+    "extensions": ["mp3"],
+    "notes": "Chromium sends this mimetype instead of audio/mpeg for mp3 files",
+    "sources": [
+      "https://bugs.chromium.org/p/chromium/issues/detail?id=227004"
+    ]
+  },
   "audio/mp4": {
     "compressible": false
   },


### PR DESCRIPTION
Because of this bug https://bugs.chromium.org/p/chromium/issues/detail?id=227004 Chromium sends `audio/mp3` as mimetype for mp3 files instead of the proper `audio/mpeg`.

Since this bug is years old, I think we might as well add the type to the list.