### PR TITLE
Extension 'wav' lookup should return mime-type 'audio/wav' (for HTML5 audio tag)

### DIFF
--- a/db.json
+++ b/db.json
@@ -5365,11 +5365,11 @@
   "audio/vorbis-config": {
     "source": "iana"
   },
-  "audio/wav": {
+  "audio/wave": {
     "compressible": false,
     "extensions": ["wav"]
   },
-  "audio/wave": {
+  "audio/wav": {
     "compressible": false,
     "extensions": ["wav"]
   },

--- a/src/custom-types.json
+++ b/src/custom-types.json
@@ -376,11 +376,11 @@
   "audio/ogg": {
     "compressible": false
   },
-  "audio/wav": {
+  "audio/wave": {
     "compressible": false,
     "extensions": ["wav"]
   },
-  "audio/wave": {
+  "audio/wav": {
     "compressible": false,
     "extensions": ["wav"]
   },


### PR DESCRIPTION
[Mime-types](https://github.com/jshttp/mime-types) npm module should return `'audio/wav'` on `mime.types['wav']` and `mime.lookup('wav')`, because html5 audio tag (Chrome, Opera, FireFox) doesn't support 'audio/wave', but 'audio/wav'
![screenshot_120](https://cloud.githubusercontent.com/assets/1378484/19312245/43b0054e-909a-11e6-9af7-e5af264acf8d.png)
![screenshot_121](https://cloud.githubusercontent.com/assets/1378484/19312266/559e051c-909a-11e6-87f2-852d1eaa071d.png)

So I have to add the following edit to **db.json**:
![screenshot_122](https://cloud.githubusercontent.com/assets/1378484/19312352/aabf5672-909a-11e6-90cc-cf85f1d4f890.png)

Now it returns `'audio/wav'`. Update please!
