### PR TITLE
Update data for application/vnd.sun.wadl+xml

### DIFF
--- a/db.json
+++ b/db.json
@@ -3854,7 +3854,8 @@
     "source": "iana"
   },
   "application/vnd.sun.wadl+xml": {
-    "source": "iana"
+    "source": "iana",
+    "extensions": ["wadl"]
   },
   "application/vnd.sun.xml.calc": {
     "source": "apache",

--- a/src/apache-types.json
+++ b/src/apache-types.json
@@ -1918,7 +1918,9 @@
     "extensions": ["sm"]
   },
   "application/vnd.street-stream": {},
-  "application/vnd.sun.wadl+xml": {},
+  "application/vnd.sun.wadl+xml": {
+    "extensions": ["wadl"]
+  },
   "application/vnd.sun.xml.calc": {
     "extensions": ["sxc"]
   },

--- a/src/custom-types.json
+++ b/src/custom-types.json
@@ -225,6 +225,13 @@
   "application/vnd.openxmlformats-officedocument.wordprocessingml.document": {
     "compressible": false
   },
+  "application/vnd.sun.wadl+xml": {
+    "compressible": true,
+    "extensions": ["wadl"],
+    "sources": [
+      "http://www.iana.org/assignments/media-types/application/vnd.sun.wadl+xml"
+    ]
+  },
   "application/x-7z-compressed": {
     "compressible": false
   },


### PR DESCRIPTION
Adding this to allow GitHub Pages to serve the correct mime type for .wadl extension. 