### PR TITLE
Update PKPASS Source Reference

### DIFF
--- a/src/custom-types.json
+++ b/src/custom-types.json
@@ -135,7 +135,7 @@
     "compressible": false,
     "extensions": ["pkpass"],
     "sources": [
-      "https://developer.apple.com/library/ios/documentation/UserExperience/Conceptual/PassKit_PG/Chapters/Creating.html"
+      "https://developer.apple.com/library/content/documentation/UserExperience/Conceptual/PassKit_PG/DistributingPasses.html"
     ]
   },
   "application/vnd.dart": {


### PR DESCRIPTION
Prior link was returning a 404.

New link seems to be: https://developer.apple.com/library/content/documentation/UserExperience/Conceptual/PassKit_PG/DistributingPasses.html