### PR TITLE
Adds iWork Keynote, Pages and Numbers

### DIFF
--- a/src/custom-types.json
+++ b/src/custom-types.json
@@ -699,5 +699,17 @@
     "sources": [
       "https://developer.mozilla.org/en-US/docs/Web/WebGL/Adding_2D_content_to_a_WebGL_context"
     ]
+  },
+  "application/x-iwork-keynote-sffkey": {
+    "compressible": false,
+    "extensions": ["key"]
+  },
+  "application/x-iwork-pages-sffpages": {
+    "compressible": false,
+    "extensions": ["pages"]
+  },
+  "application/x-iwork-keynote-sffnumbers": {
+    "compressible": false,
+    "extensions": ["numbers"]
   }
 }


### PR DESCRIPTION
Adds the types and extensions for Apples iWork Keynote, Pages and Numbers applications.

They don't appear to be registered with the IANA and I see from some previous PRs that ideally, we would look into having these added to the Apache or NGINX projects? Can you point me in their direction and I'll get the ball rolling but also accept this PR as short term solution for something I'm working on?