### PR TITLE
Add apng type

### DIFF
--- a/db.json
+++ b/db.json
@@ -5569,6 +5569,10 @@
     "compressible": true,
     "extensions": ["otf"]
   },
+  "image/apng": {
+    "compressible": false,
+    "extensions": ["apng"]
+  },
   "image/bmp": {
     "source": "iana",
     "compressible": true,

--- a/src/custom-types.json
+++ b/src/custom-types.json
@@ -417,6 +417,14 @@
       "http://www.phpied.com/gzip-your-font-face-files/"
     ]
   },
+  "image/apng": {
+    "compressible": false,
+    "extensions": ["apng"],
+    "sources": [
+      "https://wiki.mozilla.org/APNG_Specification",
+      "https://en.wikipedia.org/wiki/APNG"
+    ]
+  },
   "image/bmp": {
     "compressible": true,
     "sources": [


### PR DESCRIPTION
It's now supported in Firefox, Safari and Chromium. The mime type `image/apng` is specced, the extension is not, but I forsee no collisions so I went with it. Wikipedia also lists it as possible extension in addition to `.png`.