### PR TITLE
official mime type for markdown

### DIFF
--- a/src/custom-types.json
+++ b/src/custom-types.json
@@ -582,6 +582,10 @@
   "text/less": {
     "extensions": ["less"]
   },
+  "text/markdown": {
+    "compressible": true,
+    "extensions": ["markdown","md"]
+  },
   "text/n3": {
     "compressible": true,
     "sources": [


### PR DESCRIPTION
as per RFC 7763 - https://tools.ietf.org/html/rfc7763