### PR TITLE
Add .gz extension to 'application/gzip'

### DIFF
--- a/src/custom-types.json
+++ b/src/custom-types.json
@@ -56,7 +56,11 @@
     ]
   },
   "application/gzip": {
-    "compressible": false
+    "compressible": false,
+    "extensions": ["gz"],
+    "sources": [
+      "https://tools.ietf.org/html/rfc6713#section-3"
+    ]
   },
   "application/java-archive": {
     "compressible": false


### PR DESCRIPTION
This adds the `.gz` filename extension to the `application/gzip` MIME type,
as defined in [RFC 6713, Section 3](https://tools.ietf.org/html/rfc6713#section-3)