### PR TITLE
Add charset to text/css

### DIFF
--- a/db.json
+++ b/db.json
@@ -6144,6 +6144,7 @@
   },
   "text/css": {
     "source": "iana",
+    "charset": "UTF-8",
     "compressible": true,
     "extensions": ["css"]
   },

--- a/src/custom-types.json
+++ b/src/custom-types.json
@@ -559,6 +559,7 @@
     "extensions": ["coffee", "litcoffee"]
   },
   "text/css": {
+    "charset": "UTF-8",
     "compressible": true
   },
   "text/csv": {


### PR DESCRIPTION
> .charset - the default charset associated with this type, if any.

By default, `UTF-8` is assumed:

> When a style sheet resides in a separate file, user agents must observe the following priorities when determining a style sheet's character encoding (from highest priority to lowest):
> 
 > 1. An HTTP "charset" parameter in a "Content-Type" field (or similar parameters in other protocols)
 > 2. BOM and/or @charset (see below)
 > 3. <link charset=""> or other metadata from the linking mechanism (if any)
 > 4. charset of referring style sheet or document (if any)
 > 5. Assume UTF-8

See also:

 * https://www.w3.org/TR/CSS22/syndata.html#charset
 * https://www.w3.org/International/questions/qa-css-charset#quickanswer