### PR TITLE
Retry updating data for application/vnd.sun.wadl+xml

### DIFF
--- a/src/custom-types.json
+++ b/src/custom-types.json
@@ -237,6 +237,13 @@
   "application/vnd.openxmlformats-officedocument.wordprocessingml.document": {
     "compressible": false
   },
+  "application/vnd.sun.wadl+xml": {
+    "compressible": true,
+    "extensions": ["wadl"],
+    "sources": [
+      "http://www.iana.org/assignments/media-types/application/vnd.sun.wadl+xml"
+    ]
+  },
   "application/x-7z-compressed": {
     "compressible": false
   },


### PR DESCRIPTION
This is a do over of #58, as I messed up that one and it was closed. Made the change in the proper file now and in accordance with the contribution guidelines.

Adding this to allow GitHub Pages to serve the correct mime type for the `.wadl` extension.