### PR TITLE
Add application/fido.trusted-apps+json file type

### DIFF
--- a/src/custom-types.json
+++ b/src/custom-types.json
@@ -33,7 +33,6 @@
     "compressible": false
   },
   "application/fido.trusted-apps+json": {
-    "extensions": ["fidou2f"],
     "sources": [
       "https://fidoalliance.org/specs/fido-u2f-v1.0-ps-20141009/fido-appid-and-facets-ps-20141009.html"
     ]

--- a/src/custom-types.json
+++ b/src/custom-types.json
@@ -33,7 +33,7 @@
     "compressible": false
   },
   "application/fido.trusted-apps+json": {
-    "extensions": ["fido"],
+    "extensions": ["fidou2f"],
     "sources": [
       "https://fidoalliance.org/specs/fido-u2f-v1.0-ps-20141009/fido-appid-and-facets-ps-20141009.html"
     ]

--- a/src/custom-types.json
+++ b/src/custom-types.json
@@ -32,6 +32,12 @@
   "application/edifact": {
     "compressible": false
   },
+  "application/fido.trusted-apps+json": {
+    "extensions": ["fido"],
+    "sources": [
+      "https://fidoalliance.org/specs/fido-u2f-v1.0-ps-20141009/fido-appid-and-facets-ps-20141009.html"
+    ]
+  },
   "application/font-woff": {
     "compressible": false,
     "sources": [


### PR DESCRIPTION
For FIDO U2F trusted facet JSON files.

> The response MUST set a MIME Content-Type of "application/fido.trusted-apps+json".

Read more: https://fidoalliance.org/specs/fido-u2f-v1.0-ps-20141009/fido-appid-and-facets-ps-20141009.html

