### PR TITLE
Add extensions for JPEG-2000

### DIFF
--- a/src/custom-types.json
+++ b/src/custom-types.json
@@ -542,6 +542,30 @@
   "image/jpeg": {
     "compressible": false
   },
+  "image/jp2": {
+    "compressible": false,
+    "extensions": ["jp2","jpg2"],
+    "sources": [
+      "https://www.iana.org/assignments/media-types/image/jp2",
+      "https://tools.ietf.org/html/rfc3745"
+    ]
+  },
+    "image/jpm": {
+    "compressible": false,
+    "extensions": ["jpm"],
+    "sources": [
+      "https://www.iana.org/assignments/media-types/image/jpm",
+      "https://tools.ietf.org/html/rfc3745"
+    ]
+  },
+  "image/jpx": {
+    "compressible": false,
+    "extensions": ["jpx","jpf"],
+    "sources": [
+      "https://www.iana.org/assignments/media-types/image/jpx",
+      "https://tools.ietf.org/html/rfc3745"
+    ]
+  },
   "image/pjpeg": {
     "compressible": false
   },
@@ -805,6 +829,14 @@
   },
   "text/yaml": {
     "extensions": ["yaml","yml"]
+  },
+  "video/mj2": {
+    "compressible": false,
+    "extensions": ["mj2","mjp2"],
+    "sources": [
+      "https://www.iana.org/assignments/media-types/video/mj2",
+      "https://tools.ietf.org/html/rfc3745"
+    ]
   },
   "video/mp2t": {
     "extensions": ["ts"]


### PR DESCRIPTION
Adds support for:
* `image/jp2`
* `image/jpm`
* `image/jpx`
* `video/mj2`

