### PR TITLE
Add application/wasm

### DIFF
--- a/src/custom-types.json
+++ b/src/custom-types.json
@@ -262,7 +262,8 @@
     "extensions": ["wasm"],
     "notes": "WebAssembly module",
     "sources": [
-      "https://webassembly.github.io/spec"
+      "https://webassembly.github.io/spec",
+      "https://github.com/WebAssembly/design/blob/master/Web.md"
     ]
   },
   "application/x-7z-compressed": {

--- a/src/custom-types.json
+++ b/src/custom-types.json
@@ -262,8 +262,7 @@
     "extensions": ["wasm"],
     "notes": "WebAssembly module",
     "sources": [
-      "https://webassembly.github.io/spec",
-      "https://github.com/WebAssembly/design/blob/master/Web.md"
+      "https://webassembly.github.io/spec/binary/conventions.html"
     ]
   },
   "application/x-7z-compressed": {

--- a/src/custom-types.json
+++ b/src/custom-types.json
@@ -257,6 +257,14 @@
       "http://www.iana.org/assignments/media-types/application/vnd.sun.wadl+xml"
     ]
   },
+  "application/wasm": {
+    "compressible": true,
+    "extensions": ["wasm"],
+    "notes": "WebAssembly module",
+    "sources": [
+      "https://webassembly.github.io/spec"
+    ]
+  },
   "application/x-7z-compressed": {
     "compressible": false
   },


### PR DESCRIPTION
Eventually, 'application/wasm' should be officially registered.  In the meantime, it would be very nice to have this working on Pages since [certain WebAssembly JS APIs](https://github.com/WebAssembly/design/blob/master/Web.md#additional-web-embedding-api) require the application/wasm MIME type to work at all.