### PR TITLE
Update hjson mime type to application/hjson

### DIFF
--- a/db.json
+++ b/db.json
@@ -428,6 +428,9 @@
   "application/held+xml": {
     "source": "iana"
   },
+  "application/hjson": {
+    "extensions": ["hjson"]
+  },
   "application/http": {
     "source": "iana"
   },
@@ -6349,9 +6352,6 @@
   },
   "text/grammar-ref-list": {
     "source": "iana"
-  },
-  "text/hjson": {
-    "extensions": ["hjson"]
   },
   "text/html": {
     "source": "iana",

--- a/src/custom-types.json
+++ b/src/custom-types.json
@@ -67,6 +67,12 @@
       "https://tools.ietf.org/html/rfc6713#section-3"
     ]
   },
+  "application/hjson": {
+    "extensions": ["hjson"],
+    "sources": [
+      "https://hjson.org/rfc.html#rfc.section.1.3"
+    ]
+  },
   "application/java-archive": {
     "compressible": false
   },
@@ -709,9 +715,6 @@
   },
   "text/csv": {
     "compressible": true
-  },
-  "application/hjson": {
-    "extensions": ["hjson"]
   },
   "text/html": {
     "compressible": true

--- a/src/custom-types.json
+++ b/src/custom-types.json
@@ -710,7 +710,7 @@
   "text/csv": {
     "compressible": true
   },
-  "text/hjson": {
+  "application/hjson": {
     "extensions": ["hjson"]
   },
   "text/html": {


### PR DESCRIPTION
# Description

The `hjson` [RFC](https://hjson.org/rfc.html#rfc.section.1.3) defines the mime type to be
`application/hjson` not `text/hjson`; see https://hjson.org/rfc.html#rfc.section.1.3

This PR update the mime type according to the RFC