### PR TITLE
WOFF is compressible

### DIFF
--- a/db.json
+++ b/db.json
@@ -384,7 +384,7 @@
   },
   "application/font-woff": {
     "source": "iana",
-    "compressible": false,
+    "compressible": true,
     "extensions": ["woff"]
   },
   "application/framework-attributes+xml": {


### PR DESCRIPTION
See https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/webfont-optimization?hl=en

> Note: Consider using Zopfli compression for the EOT, TTF, and WOFF formats. Zopfli is a zlib compatible compressor that delivers ~5% file-size reduction over gzip.