### PR TITLE
fix: `woff` is compressible

### DIFF
--- a/db.json
+++ b/db.json
@@ -384,7 +384,7 @@
   },
   "application/font-woff": {
     "source": "iana",
-    "compressible": false,
+    "compressible": true,
     "extensions": ["woff"]
   },
   "application/framework-attributes+xml": {

--- a/src/custom-types.json
+++ b/src/custom-types.json
@@ -38,7 +38,7 @@
     ]
   },
   "application/font-woff": {
-    "compressible": false,
+    "compressible": true,
     "sources": [
       "https://github.com/h5bp/server-configs-apache/issues/42"
     ],


### PR DESCRIPTION
See https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/webfont-optimization?hl=en

> Note: Consider using Zopfli compression for the EOT, TTF, and WOFF formats. Zopfli is a zlib compatible compressor that delivers ~5% file-size reduction over gzip.

Based on https://github.com/jshttp/mime-db/pull/108.
@dougwilson friendly ping :+1: 