### PR TITLE
Add image/webp

### DIFF
--- a/src/custom-types.json
+++ b/src/custom-types.json
@@ -591,6 +591,15 @@
   "image/vnd.adobe.photoshop": {
     "compressible": true
   },
+  "image/webp": {
+    "compressible": false,
+    "extensions": ["webp"],
+    "sources": [
+      "https://developers.google.com/speed/webp/faq",
+      "https://developers.google.com/speed/webp/",
+      "https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types#Discrete_types"
+    ]
+  },
   "image/x-icon": {
     "compressible": true,
     "sources": [


### PR DESCRIPTION
Although not all browsers support webp those outside Android / Chrome the mime type is still needed for images.

https://caniuse.com/#search=webp
https://css-tricks.com/using-webp-images/#post-244917