### PR TITLE
Update "application/vnd.citationstyles.style+xml"

### DIFF
--- a/src/custom-types.json
+++ b/src/custom-types.json
@@ -170,6 +170,7 @@
     ]
   },
   "application/vnd.citationstyles.style+xml": {
+    "compressible": true,
     "extensions": ["csl"],
     "sources": [
       "https://www.iana.org/assignments/media-types/application/vnd.citationstyles.style+xml"

--- a/src/custom-types.json
+++ b/src/custom-types.json
@@ -169,6 +169,12 @@
       "https://developer.apple.com/library/content/documentation/UserExperience/Conceptual/PassKit_PG/DistributingPasses.html"
     ]
   },
+  "application/vnd.citationstyles.style+xml": {
+    "extensions": ["csl"],
+    "sources": [
+      "https://www.iana.org/assignments/media-types/application/vnd.citationstyles.style+xml"
+    ]
+  },
   "application/vnd.dart": {
     "compressible": true
   },


### PR DESCRIPTION
Add .csl extension, add URL to IANA registration page.

I wasn't sure about the "compressible" setting (these files always consist of plain XML, so I guess it makes sense to compress them?). Is `"compressible": false` only for files that wouldn't benefit much from additional compression, like zip files?

This is for Citation Style Language (CSL) citation styles that have an .csl extension. I registered the "application/vnd.citationstyles.style+xml" MIME type myself at IANA. See https://www.iana.org/assignments/media-types/application/vnd.citationstyles.style+xml.