### PR TITLE
Clean up +json entries in custom-types.json

### DIFF
--- a/src/custom-types.json
+++ b/src/custom-types.json
@@ -31,6 +31,11 @@
   "application/edifact": {
     "compressible": false
   },
+  "application/fido.trusted-apps+json": {
+    "sources": [
+      "https://fidoalliance.org/specs/fido-u2f-v1.0-ps-20141009/fido-appid-and-facets-ps-20141009.html"
+    ]
+  },
   "application/font-woff": {
     "compressible": false,
     "sources": [

--- a/src/custom-types.json
+++ b/src/custom-types.json
@@ -31,11 +31,6 @@
   "application/edifact": {
     "compressible": false
   },
-  "application/fido.trusted-apps+json": {
-    "sources": [
-      "https://fidoalliance.org/specs/fido-u2f-v1.0-ps-20141009/fido-appid-and-facets-ps-20141009.html"
-    ]
-  },
   "application/font-woff": {
     "compressible": false,
     "sources": [

--- a/src/custom-types.json
+++ b/src/custom-types.json
@@ -39,7 +39,6 @@
     "notes": "File type is already a binary compressed format."
   },
   "application/geo+json": {
-    "compressible": true,
     "extensions": ["geojson"],
     "sources": [
       "http://tools.ietf.org/rfc/rfc7946.txt",
@@ -589,7 +588,6 @@
     ]
   },
   "model/gltf+json": {
-    "compressible": true,
     "extensions": ["gltf"],
     "sources": [
       "https://github.com/KhronosGroup/glTF/tree/master/specification/2.0"


### PR DESCRIPTION
* Remove redundant "compressible" property for +json types (since this is already defined for all +json types in custom-suffix.json)
* (removed from PR) Remove "application/fido.trusted-apps+json" entry since it only has the "sources" property