### PR TITLE
add charset for text/turtle

### DIFF
--- a/src/custom-types.json
+++ b/src/custom-types.json
@@ -723,6 +723,12 @@
   "text/tab-separated-values": {
     "compressible": true
   },
+  "text/turtle": {
+    "charset": "UTF-8",
+    "sources": [
+      "https://www.w3.org/TR/turtle/#h3_sec-mime"
+    ]
+  },
   "text/uri-list": {
     "compressible": true
   },


### PR DESCRIPTION
From the specification https://www.w3.org/TR/turtle/#h3_sec-mime:
> The content encoding of Turtle content is always UTF-8.
