### PR TITLE
Add text/event-stream with compressible: false

### DIFF
--- a/db.json
+++ b/db.json
@@ -6918,6 +6918,9 @@
   "text/enriched": {
     "source": "iana"
   },
+  "text/event-stream": {
+    "compressible": false
+  },
   "text/fwdred": {
     "source": "iana"
   },


### PR DESCRIPTION
Server-sent events should not be buffered by the server and therefore should not be compressed.

Currently, the express middleware `compression` prevents SSE messages from going through properly. This should fix it.