### PR TITLE
Added .acl file support

### DIFF
--- a/src/custom-types.json
+++ b/src/custom-types.json
@@ -666,6 +666,15 @@
   "multipart/signed": {
     "compressible": false
   },
+  "text/acl": {
+    "compressible": true,
+    "extensions": ["acl"],
+    "sources": [
+      "https://www.w3.org/wiki/WebAccessControl",
+      "https://github.com/solid/web-access-control-spec"
+    ],
+    "notes": "Decentralized file permissions"
+  },
   "text/cache-manifest": {
     "compressible": true,
     "extensions": ["manifest"],


### PR DESCRIPTION
I noticed there is no support for .acl files, which are permissions files used by the solid platform. For more information, check out 
* https://www.w3.org/wiki/WebAccessControl
* https://github.com/solid/web-access-control-spec