### PR TITLE
Support for application/x-zip-compressed and application/x-zip

### DIFF
--- a/db.json
+++ b/db.json
@@ -5583,6 +5583,12 @@
     "source": "apache",
     "extensions": ["xz"]
   },
+  "application/x-zip": {
+    "extensions": ["zip"]
+  },
+  "application/x-zip-compressed": {
+    "extensions": ["zip"]
+  },
   "application/x-zmachine": {
     "source": "apache",
     "extensions": ["z1","z2","z3","z4","z5","z6","z7","z8"]

--- a/src/custom-types.json
+++ b/src/custom-types.json
@@ -434,13 +434,13 @@
   "application/x-zip": {
     "extensions": ["zip"],
     "sources": [
-      "http://filext.com/file-extension/ZIP"
+      "https://www.oreilly.com/library/view/web-design-in/0596009879/ch04s05.html"
     ]
   },
   "application/x-zip-compressed": {
     "extensions": ["zip"],
     "sources": [
-      "http://filext.com/file-extension/ZIP"
+      "https://www.oreilly.com/library/view/web-design-in/0596009879/ch04s05.html"
     ]
   },
   "application/xml-dtd": {

--- a/src/custom-types.json
+++ b/src/custom-types.json
@@ -431,6 +431,18 @@
       "http://en.wikipedia.org/wiki/RELAX_NG"
     ]
   },
+  "application/x-zip": {
+    "extensions": ["zip"],
+    "sources": [
+      "http://filext.com/file-extension/ZIP"
+    ]
+  },
+  "application/x-zip-compressed": {
+    "extensions": ["zip"],
+    "sources": [
+      "http://filext.com/file-extension/ZIP"
+    ]
+  },
   "application/xml-dtd": {
     "compressible": true,
     "sources": [


### PR DESCRIPTION
When a Windows user converts a folder to a zip file, the filetype becomes: `x-zip-compressed` as shown below (using the `mime-types` npm package, which utilizes this package):
![image](https://user-images.githubusercontent.com/16158417/50715706-794a9280-104c-11e9-82e3-6ffbd953ac1c.png)

There are a few sources, however I am having trouble finding one that isn't an aggregated list:

Closest I can find is SitePoint:
https://www.sitepoint.com/mime-types-complete-list/
http://filext.com/file-extension/ZIP

My company will be using my forked branch in the meantime, as we have windows users uploading zip files pretty regularly.  Let me know if there is anything else I can do.