### PR TITLE
Updated README from using RawGit to jsDelivr

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,12 +24,12 @@ npm install mime-db
 ### Database Download
 
 If you're crazy enough to use this in the browser, you can just grab the
-JSON file using [RawGit](https://rawgit.com/). It is recommended to replace
-`master` with [a release tag](https://github.com/jshttp/mime-db/tags) as the
-JSON format may change in the future.
+JSON file using [jsDelivr](https://www.jsdelivr.com/). It is recommended to
+replace `master` with [a release tag](https://github.com/jshttp/mime-db/tags)
+as the JSON format may change in the future.
 
 ```
-https://cdn.rawgit.com/jshttp/mime-db/master/db.json
+https://cdn.jsdelivr.net/gh/jshttp/mime-db@master/db.json
 ```
 
 ## Usage


### PR DESCRIPTION
As RawGit is in sunset phase, we should change the link in README to using a more reliable service like `jsDelivr ` instead