### PR TITLE
Add 'compressible' to text/less mime type

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -2,6 +2,7 @@ unreleased
 ==========
 
   * Add new upstream MIME types
+  * Mark `text/less` as compressible
 
 1.37.0 / 2018-10-19
 ===================

--- a/db.json
+++ b/db.json
@@ -7098,6 +7098,7 @@
     "extensions": ["jsx"]
   },
   "text/less": {
+    "compressible": true,
     "extensions": ["less"]
   },
   "text/markdown": {

--- a/src/custom-types.json
+++ b/src/custom-types.json
@@ -714,6 +714,7 @@
     ]
   },
   "text/less": {
+    "compressible": true,
     "extensions": ["less"]
   },
   "text/markdown": {


### PR DESCRIPTION
*.less files is just an ordinary text and they should be compressed (gzipped) when requested from the server (if someone wants to request *.less files)