### PR TITLE
Add extensions .siv and .sieve to application/sieve

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,6 +1,7 @@
 unreleased
 ==========
 
+  * Add extensions `.siv` and `.sieve` to `application/sieve`
   * Add new upstream MIME types
 
 1.38.0 / 2019-02-04

--- a/db.json
+++ b/db.json
@@ -1333,7 +1333,8 @@
     "extensions": ["shf"]
   },
   "application/sieve": {
-    "source": "iana"
+    "source": "iana",
+    "extensions": ["siv","sieve"]
   },
   "application/simple-filter+xml": {
     "source": "iana",

--- a/src/custom-types.json
+++ b/src/custom-types.json
@@ -154,6 +154,13 @@
       "https://www.w3.org/TR/owl-ref/#MIMEType"
     ]
   },
+  "application/sieve": {
+    "extensions": ["siv","sieve"],
+    "sources": [
+      "https://tools.ietf.org/rfc/rfc5228.txt",
+      "https://www.iana.org/assignments/media-types/application/sieve"
+    ]
+  },
   "application/tar": {
     "compressible": true
   },


### PR DESCRIPTION
- I copied the `application/sieve` entry from `src/iana-types.json`.
- I changed `http` to `https` for both `sources` (the same documents are served over https too).
- I added the 2 `extensions`.
Up to you which extension should be preferred (first in the array): you know what that means and how it's used:
  - First chronologically? Both sources list them in the order `.siv`, `.sieve` and the RFC says `.sieve` was added later.
  - The most semantic (most clear) extension? To me that's `.sieve`.
  - To resolve collisions? Other words (MIME types) could conceivably be abbreviated to `.siv`, but for each request the webserver has to pick one MIME type.
- `npm run build`
- I added an entry to HISTORY.md as I saw in other recent commits.

https://help.github.com/en/articles/mime-types-on-github-pages says this repository is used by GitHub Pages. I've put a small text file `filter.sieve` on GitHub Pages: it's now served as
```HTTP
content-type: application/octet-stream
```
Did I understand correctly: if my change is accepted, GitHub Pages will serve such files as `application/sieve` soon afterwards?