### PR TITLE
mark application/octet-stream as compressible

### DIFF
--- a/db.json
+++ b/db.json
@@ -922,7 +922,7 @@
   },
   "application/octet-stream": {
     "source": "iana",
-    "compressible": false,
+    "compressible": true,
     "extensions": ["bin","dms","lrf","mar","so","dist","distz","pkg","bpk","dump","elc","deploy","exe","dll","deb","dmg","iso","img","msi","msp","msm","buffer"]
   },
   "application/oda": {


### PR DESCRIPTION
didn't see anything in iana rfc about this not being compressible.

I see a few extensions that are probably already compressed like distz and dmg but overall most things sent as application/octet-stream would benefit from compression it seems.