### PR TITLE
Added "ejs" file extension to type "application/javascript".

### DIFF
--- a/src/custom-types.json
+++ b/src/custom-types.json
@@ -75,7 +75,7 @@
   "application/javascript": {
     "charset": "UTF-8",
     "compressible": true,
-    "extensions": ["mjs"],
+    "extensions": ["mjs","ejs"],
     "sources": [
       "https://tools.ietf.org/html/draft-bfarias-javascript-mjs-00"
     ]


### PR DESCRIPTION
Added "ejs" file extension to type "application/javascript" which is used as well as "mjs" extension for ES6 Modules.