### PR TITLE
Set charset to UTF-8 for image/svg+xml

### DIFF
--- a/db.json
+++ b/db.json
@@ -6680,6 +6680,7 @@
   },
   "image/svg+xml": {
     "source": "iana",
+    "charset": "UTF-8",
     "compressible": true,
     "extensions": ["svg","svgz"]
   },

--- a/src/custom-types.json
+++ b/src/custom-types.json
@@ -675,6 +675,9 @@
   "multipart/signed": {
     "compressible": false
   },
+  "image/svg+xml": {
+    "charset": "UTF-8"
+  },
   "text/cache-manifest": {
     "compressible": true,
     "extensions": ["manifest"],


### PR DESCRIPTION
first reported here: https://github.com/jshttp/mime-types/issues/66