### PR TITLE
Enable compression for TTF font format

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -3,6 +3,7 @@ unreleased
 
   * Add new upstream MIME types
   * Add `application/toml` with extension `.toml`
+  * Mark `font/ttf` as compressible
 
 1.40.0 / 2019-04-20
 ===================

--- a/db.json
+++ b/db.json
@@ -6518,6 +6518,7 @@
   },
   "font/ttf": {
     "source": "iana",
+    "compressible": true,
     "extensions": ["ttf"]
   },
   "font/woff": {

--- a/src/custom-types.json
+++ b/src/custom-types.json
@@ -526,6 +526,13 @@
       "http://www.phpied.com/gzip-your-font-face-files/"
     ]
   },
+  "font/ttf": {
+    "compressible": true,
+    "sources": [
+      "https://www.iana.org/assignments/media-types/font/ttf",
+      "http://www.phpied.com/gzip-your-font-face-files/"
+    ]
+  },
   "image/apng": {
     "compressible": false,
     "extensions": ["apng"],


### PR DESCRIPTION
 TTF formats are not compressed by default. I think compression should be enabled so that others compression libraries which rely on this db can enable the font/ttf compression by default. 