### PR TITLE
Remove compressible from multipart/mixed

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -2,6 +2,7 @@ unreleased
 ==========
 
   * Add new upstream MIME types
+  * Remove compressible from `multipart/mixed`
 
 1.41.0 / 2019-08-30
 ===================

--- a/db.json
+++ b/db.json
@@ -7155,8 +7155,7 @@
     "source": "iana"
   },
   "multipart/mixed": {
-    "source": "iana",
-    "compressible": false
+    "source": "iana"
   },
   "multipart/multilingual": {
     "source": "iana"

--- a/src/custom-types.json
+++ b/src/custom-types.json
@@ -680,9 +680,6 @@
   "multipart/form-data": {
     "compressible": false
   },
-  "multipart/mixed": {
-    "compressible": false
-  },
   "multipart/related": {
     "compressible": false
   },


### PR DESCRIPTION
The media type multipart/mixed is essentially a textual media type, it uses "boundary delimiter lines" terminated by CRLF to separate the parts of a request, see https://tools.ietf.org/html/rfc2046#section-5.1:

> The body must then contain
   one or more body parts, each preceded by a boundary delimiter line,
   and the last one followed by a closing boundary delimiter line.
   After its boundary delimiter line, each body part then consists of a
   header area, a blank line, and a body area. 

This media type is used e.g. in Batch request and response bodies as defined by the OASIS and ISO standard Open Data Protocol (OData), see http://docs.oasis-open.org/odata/odata/v4.0/errata03/os/complete/part1-protocol/odata-v4.0-errata03-os-part1-protocol-complete.html#_Toc453752315.

In OData the parts of a multipart/mixed message are typically JSON requests and responses, grouped for performance reasons, or to form "change sets" that are committed or rolled back as a logical unit of work.

Examples from the specification:
```
POST /service/$batch HTTP/1.1
Host: host
OData-Version: 4.0
Content-Type: multipart/mixed; boundary=batch_36522ad7-fc75-4b56-8c71-56071383e77b

Content-Length: ###

 

--batch_36522ad7-fc75-4b56-8c71-56071383e77b
Content-Type: application/http

GET /service/Customers('ALFKI')
Host: host


--batch_36522ad7-fc75-4b56-8c71-56071383e77b
Content-Type: multipart/mixed; boundary=changeset_77162fcd-b8da-41ac-a9f8-9357efbbd

--changeset_77162fcd-b8da-41ac-a9f8-9357efbbd
Content-Type: application/http
Content-ID: 1

POST /service/Customers HTTP/1.1
Host: host
Content-Type: application/json
Content-Length: ###

<JSON representation of a new Customer>

--changeset_77162fcd-b8da-41ac-a9f8-9357efbbd
Content-Type: application/http
Content-ID: 2

PATCH /service/Customers('ALFKI') HTTP/1.1
Host: host
Content-Type: application/json
If-Match: xxxxx
Content-Length: ###

<JSON representation of Customer ALFKI>

--changeset_77162fcd-b8da-41ac-a9f8-9357efbbd--
--batch_36522ad7-fc75-4b56-8c71-56071383e77b
Content-Type: application/http

GET /service/Products HTTP/1.1
Host: host


--batch_36522ad7-fc75-4b56-8c71-56071383e77b--
```

A possible response to the above request could be
```
HTTP/1.1 200 Ok
OData-Version: 4.0
Content-Length: ####
Content-Type: multipart/mixed; boundary=b_243234_25424_ef_892u748

--b_243234_25424_ef_892u748
Content-Type: application/http

HTTP/1.1 200 Ok
Content-Type: application/json
Content-Length: ###

<JSON representation of the Customer entity with EntityKey ALFKI>

--b_243234_25424_ef_892u748
Content-Type: multipart/mixed; boundary=cs_12u7hdkin252452345eknd_383673037

--cs_12u7hdkin252452345eknd_383673037
Content-Type: application/http
Content-ID: 1

HTTP/1.1 201 Created
Content-Type: application/json
Location: http://host/service.svc/Customer('POIUY')
Content-Length: ###

<JSON representation of a new Customer entity>

--cs_12u7hdkin252452345eknd_383673037
Content-Type: application/http
Content-ID: 2

HTTP/1.1 204 No Content
Host: host


--cs_12u7hdkin252452345eknd_383673037--

--b_243234_25424_ef_892u748
Content-Type: application/http

HTTP/1.1 404 Not Found
Content-Type: application/xml
Content-Length: ###

<JSON error message>
--b_243234_25424_ef_892u748--
```

So the majority of the multipart/mixed message in these cases is text: the wrapper text of multipart/mixed itself, plus the JSON or XML text in the bodies of the parts. Occasionally intermingled non-text parts do not pose a problem because these octet streams are preserved during compression/decompression and may benefit from compression.

This has been successfully used in thousands of production environments with servers built on Java, .NET, and ABAP stacks, browser-based clients, and native clients on Java (Android), iOS, Java, .NET, and others. It's only our new Node.js-based server that insists on not compressing multipart/mixed messages due to this flag.

Thanks in advance
Ralf Handl