### PR TITLE
Add application/x-python-code and text/x-python

### DIFF
--- a/db.json
+++ b/db.json
@@ -5653,6 +5653,9 @@
     "source": "apache",
     "extensions": ["p7r"]
   },
+  "application/x-python-code": {
+    "extensions": ["pyc","pyo"]
+  },
   "application/x-rar-compressed": {
     "source": "apache",
     "compressible": false,
@@ -7611,6 +7614,9 @@
   "text/x-processing": {
     "compressible": true,
     "extensions": ["pde"]
+  },
+  "text/x-python": {
+    "extensions": ["py"]
   },
   "text/x-sass": {
     "extensions": ["sass"]

--- a/src/custom-types.json
+++ b/src/custom-types.json
@@ -136,6 +136,12 @@
   "application/postscript": {
     "compressible": true
   },
+  "application/x-python-code": {
+    "extensions": ["pyc", "pyo"],
+    "sources": [
+      "https://github.com/python/cpython/blob/19a3d873005e5730eeabdc394c961e93f2ec02f0/Lib/mimetypes.py#L457"
+    ]
+  },
   "application/raml+yaml": {
     "compressible": true,
     "extensions": ["raml"],
@@ -856,6 +862,12 @@
     "extensions": ["pde"],
     "sources": [
       "https://en.wikipedia.org/wiki/Processing_(programming_language)"
+    ]
+  },
+  "text/x-python": {
+    "extensions": ["py"],
+    "sources": [
+      "https://github.com/python/cpython/blob/19a3d873005e5730eeabdc394c961e93f2ec02f0/Lib/mimetypes.py#L528"
     ]
   },
   "text/x-sass": {


### PR DESCRIPTION
Noticed they weren't here since `.py` files are being downloaded instead of displayed in the browser on GitHub pages.