### PR TITLE
Added Microsoft AppInstaller Mime-Types

### DIFF
--- a/db.json
+++ b/db.json
@@ -67,12 +67,24 @@
     "source": "iana",
     "extensions": ["ez"]
   },
+  "application/appinstaller": {
+    "compressible": true,
+    "extensions": ["appinstaller"]
+  },
   "application/applefile": {
     "source": "iana"
   },
   "application/applixware": {
     "source": "apache",
     "extensions": ["aw"]
+  },
+  "application/appx": {
+    "compressible": false,
+    "extensions": ["appx"]
+  },
+  "application/appxbundle": {
+    "compressible": false,
+    "extensions": ["appxbundle"]
   },
   "application/atf": {
     "source": "iana"
@@ -883,6 +895,14 @@
   "application/msc-mixer+xml": {
     "source": "iana",
     "compressible": true
+  },
+  "application/msix": {
+    "compressible": false,
+    "extensions": ["msix"]
+  },
+  "application/msixbundle": {
+    "compressible": false,
+    "extensions": ["msixbundle"]
   },
   "application/msword": {
     "source": "iana",

--- a/src/custom-types.json
+++ b/src/custom-types.json
@@ -1,4 +1,31 @@
 {
+  "application/appinstaller": {
+    "compressible": true,
+    "extensions": ["appinstaller"],
+    "notes": "Microsoft Windows AppInstaller XML Manifest",
+    "sources": [
+      "https://docs.microsoft.com/en-us/windows/msix/app-installer/web-install-iis",
+      "https://docs.microsoft.com/en-us/windows/msix/app-installer/web-install-azure"
+    ]
+  },
+  "application/appx": {
+    "compressible": false,
+    "extensions": ["appx"],
+    "notes": "Microsoft Windows AppX Package",
+    "sources": [
+      "https://docs.microsoft.com/en-us/windows/msix/app-installer/web-install-iis",
+      "https://docs.microsoft.com/en-us/windows/msix/app-installer/web-install-azure"
+    ]
+  },
+  "application/appxbundle": {
+    "compressible": false,
+    "extensions": ["appxbundle"],
+    "notes": "Microsoft Windows AppX Bundle Package",
+    "sources": [
+      "https://docs.microsoft.com/en-us/windows/msix/app-installer/web-install-iis",
+      "https://docs.microsoft.com/en-us/windows/msix/app-installer/web-install-azure"
+    ]
+  },
   "application/bdoc": {
     "compressible": false,
     "extensions": ["bdoc"],
@@ -101,6 +128,24 @@
   },
   "application/mp4": {
     "extensions": ["m4p"]
+  },
+  "application/msix": {
+    "compressible": false,
+    "extensions": ["msix"],
+    "notes": "Microsoft Windows MSIX Package",
+    "sources": [
+      "https://docs.microsoft.com/en-us/windows/msix/app-installer/web-install-iis",
+      "https://docs.microsoft.com/en-us/windows/msix/app-installer/web-install-azure"
+    ]
+  },
+  "application/msixbundle": {
+    "compressible": false,
+    "extensions": ["msixbundle"],
+    "notes": "Microsoft Windows MSIX Bundle Package",
+    "sources": [
+      "https://docs.microsoft.com/en-us/windows/msix/app-installer/web-install-iis",
+      "https://docs.microsoft.com/en-us/windows/msix/app-installer/web-install-azure"
+    ]
   },
   "application/msword": {
     "compressible": false


### PR DESCRIPTION
Microsoft now allows Windows 10 App packages to be distributed from Websites by using appinstaller files and simply publishing the used packages via HTTP.
Sadly, the installer seems sensitive to the correct Mime-Type being sent by the Webserver, which is why they included custom Mime-Types in their setup guide. This adds those mime-types. Luckily they map 1:1 with the custom extensions used for the package files.