### PR TITLE
Add "license" as an extension to text/plain

### DIFF
--- a/src/custom-types.json
+++ b/src/custom-types.json
@@ -736,7 +736,7 @@
   },
   "text/plain": {
     "compressible": true,
-    "extensions": ["ini"]
+    "extensions": ["ini","license"]
   },
   "text/richtext": {
     "compressible": true


### PR DESCRIPTION
I was working through a build error with terraform that uses `mime-types` (https://github.com/jshttp/mime-types) to perform validation on the files.  Any way, the file example below blew up on me because it didn't recognize `.license`. 

Running this command seems to show the mime type is `text/plain`.

```bash
file --mime-type -b vendors~main.bundle.js.LICENSE
text/plain
```