### PR TITLE
Associate .cjs extension with application/node

### DIFF
--- a/src/custom-types.json
+++ b/src/custom-types.json
@@ -65,8 +65,9 @@
   "application/javascript": {
     "charset": "UTF-8",
     "compressible": true,
-    "extensions": ["mjs"],
+    "extensions": ["cjs", "mjs"],
     "sources": [
+      "https://nodejs.org/docs/latest-v13.x/api/esm.html#esm_package_scope_and_file_extensions",
       "https://tools.ietf.org/html/draft-bfarias-javascript-mjs-00"
     ]
   },

--- a/src/custom-types.json
+++ b/src/custom-types.json
@@ -65,9 +65,8 @@
   "application/javascript": {
     "charset": "UTF-8",
     "compressible": true,
-    "extensions": ["cjs", "mjs"],
+    "extensions": ["mjs"],
     "sources": [
-      "https://nodejs.org/docs/latest-v13.x/api/esm.html#esm_package_scope_and_file_extensions",
       "https://tools.ietf.org/html/draft-bfarias-javascript-mjs-00"
     ]
   },
@@ -92,6 +91,9 @@
   },
   "application/msword": {
     "compressible": false
+  },
+  "application/node": {
+    "extensions": ["cjs"]
   },
   "application/octet-stream": {
     "compressible": false,


### PR DESCRIPTION
Script files with `.cjs` extensions are interpreted as CommonJS and (from what I can tell) should have the IANA designated `application/node` MIME type, even though the IANA registry entry predates the `.cjs` extension and does not mention `.cjs`. Someone from the https://github.com/nodejs/modules working group probably knows the deets better than me though.

Hopefully I updated the correct file 😄. Thoughts?