### PR TITLE
Patched keynote extension

### DIFF
--- a/db.json
+++ b/db.json
@@ -2004,7 +2004,7 @@
   },
   "application/vnd.apple.keynote": {
     "source": "iana",
-    "extensions": ["keynote"]
+    "extensions": ["key"]
   },
   "application/vnd.apple.mpegurl": {
     "source": "iana",

--- a/src/iana-types.json
+++ b/src/iana-types.json
@@ -2775,7 +2775,7 @@
     ]
   },
   "application/vnd.apple.keynote": {
-    "extensions": ["keynote"],
+    "extensions": ["key"],
     "sources": [
       "http://www.iana.org/assignments/media-types/application/vnd.apple.keynote"
     ]


### PR DESCRIPTION
The file extension for keynote is incorrect. 
It is marked as `.keynote` instead of `.key` .