### PR TITLE
Added reStructuredText mime type

### DIFF
--- a/src/custom-types.json
+++ b/src/custom-types.json
@@ -817,8 +817,7 @@
     "compressible": true,
     "extensions": ["rst"],
     "sources": [
-      "https://docutils.sourceforge.io/rst.html",
-      "https://en.wikipedia.org/wiki/ReStructuredText"
+      "https://docutils.sourceforge.io/rst.html"
     ]
   },
   "text/x-sass": {

--- a/src/custom-types.json
+++ b/src/custom-types.json
@@ -813,6 +813,14 @@
       "https://en.wikipedia.org/wiki/Processing_(programming_language)"
     ]
   },
+  "text/x-rst": {
+    "compressible": true,
+    "extensions": ["rst"],
+    "sources": [
+      "https://docutils.sourceforge.io/rst.html",
+      "https://en.wikipedia.org/wiki/ReStructuredText"
+    ]
+  },
   "text/x-sass": {
     "extensions": ["sass"]
   },


### PR DESCRIPTION
Added support to handle reStructuredText files. They have mime-type "text/x-rst" and extension ".rst" .