### PR TITLE
Update custom-types.json

### DIFF
--- a/src/custom-types.json
+++ b/src/custom-types.json
@@ -686,6 +686,10 @@
   "text/cmd": {
     "compressible": true
   },
+  "text/comma-separated-values": {
+    "compressible": true,
+    "extensions": ["csv"]
+  },
   "text/coffeescript": {
     "extensions": ["coffee","litcoffee"]
   },


### PR DESCRIPTION
Android reads text/csv types as text/comma-separated-values