### PR TITLE
Reorder the markdown extensions

### DIFF
--- a/src/custom-types.json
+++ b/src/custom-types.json
@@ -721,7 +721,7 @@
   },
   "text/markdown": {
     "compressible": true,
-    "extensions": ["markdown","md"],
+    "extensions": ["md","markdown"],
     "sources": [
       "https://tools.ietf.org/html/rfc7763"
     ]


### PR DESCRIPTION
md is the most common extension for markdown. And it is also the first listed one in the IANA assignment.
Listing it first helps with tools wanting to choose an extension for a given mime type.

See https://www.iana.org/assignments/media-types/text/markdown for the reference (scroll to the `Additional information` section)