### PR TITLE
Sort audio/mpeg file extensions to the most common one

### DIFF
--- a/src/custom-types.json
+++ b/src/custom-types.json
@@ -453,7 +453,7 @@
   },
   "audio/mp3": {
     "compressible": false,
-    "extensions": ["mp3"],
+    "extensions": ["mp3","mpga","mp2","mp2a","m2a","m3a"],
     "notes": "Chromium sends this mimetype instead of audio/mpeg for mp3 files",
     "sources": [
       "https://bugs.chromium.org/p/chromium/issues/detail?id=227004"


### PR DESCRIPTION
The `audio/mpeg` mime is used mostly with the `mp3` extension. This pull request just sorts these file extensions to the most common one. It also adds a new one: `mp1` defined in [the RFC 3003 (page 3)](https://tools.ietf.org/html/rfc3003).
*[Related comment](https://github.com/symfony/symfony/pull/37422#discussion_r446059439)*