### PR TITLE
Add mime to extension mapping audio/flac -> flac

### DIFF
--- a/src/custom-types.json
+++ b/src/custom-types.json
@@ -455,6 +455,12 @@
   "audio/basic": {
     "compressible": false
   },
+  "audio/flac": {
+    "sources": [
+      "https://wiki.xiph.org/index.php?title=MIME_Types_and_File_Extensions"
+    ],
+    "extensions": ["flac"]
+  },
   "audio/l24": {
     "compressible": false
   },


### PR DESCRIPTION
DB already has `audio/x-flac` => `flac` mime to extension mapping. This adds `audio/flac` => `flac`. `audio/flac` does not appear to be in IANA, however it is in Apache servers default mime types and listed as the MIME type for FLAC in numerous places. Sources:

  - `audio/flac` is listed in Apache 2 serve mime.types file -- http://apache.mirror.amaze.com.au//httpd/httpd-2.4.43.tar.gz
  - `audio/flac` is listed in the `mime.types` file provided by Debian [mime-support](https://packages.debian.org/buster/mime-support) package. This is actually the default TypesConfig file used by Apache 2 server, and other softwares on Debian.
  - [Mozdev](https://developer.mozilla.org/en-US/docs/Web/Media/Formats/Containers#FLAC) states the two MIME types for FLAC are `audio/flac` and `audio/x-flac` (non standard).
  - [Wikipedia](https://en.wikipedia.org/wiki/FLAC) lists `audio/flac` and `.flac` as the extension. Does not mention `audio/x-flac`.

More testing in Debian Linux (these utils probably just use /etc/mime.types DB):

```
> lsb_release -d
Description:	Debian GNU/Linux 10 (buster)
> file --mime-type  sample.flac
sample.flac: audio/flac
> php -v
PHP 7.3.19-1~deb10u1 (cli) (built: Jul  5 2020 06:46:45) ( NTS )
> php -r 'print(mime_content_type("sample.flac") . "\n");'
audio/flac
```