### PR TITLE
Add mime-support as upstream source for MIME types.

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,10 +49,10 @@ The JSON file is a map lookup for lowercased mime types.
 Each mime type has the following properties:
 
 - `.source` - where the mime type is defined.
-    If not set, it's probably a custom media type.
     - `apache` - [Apache common media types](http://svn.apache.org/repos/asf/httpd/httpd/trunk/docs/conf/mime.types)
     - `iana` - [IANA-defined media types](http://www.iana.org/assignments/media-types/media-types.xhtml)
     - `nginx` - [nginx media types](http://hg.nginx.org/nginx/raw-file/default/conf/mime.types)
+    - `custom` - Loaded from custom set of types maintained in this repository.
 - `.extensions[]` - known extensions associated with this mime type.
 - `.compressible` - whether a file of this type can be gzipped.
 - `.charset` - the default charset associated with this type, if any.

--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ Each mime type has the following properties:
     - `apache` - [Apache common media types](http://svn.apache.org/repos/asf/httpd/httpd/trunk/docs/conf/mime.types)
     - `iana` - [IANA-defined media types](http://www.iana.org/assignments/media-types/media-types.xhtml)
     - `nginx` - [nginx media types](http://hg.nginx.org/nginx/raw-file/default/conf/mime.types)
+    - `mime-support` [Debian Linux mime.types database (upstream source)](https://salsa.debian.org/debian/mime-support/-/raw/master/mime.types)
     - `custom` - Loaded from custom set of types maintained in this repository.
 - `.extensions[]` - known extensions associated with this mime type.
 - `.compressible` - whether a file of this type can be gzipped.

--- a/db.json
+++ b/db.json
@@ -76,6 +76,10 @@
     "source": "iana",
     "extensions": ["ez"]
   },
+  "application/annodex": {
+    "source": "mime-support",
+    "extensions": ["anx"]
+  },
   "application/applefile": {
     "source": "iana"
   },
@@ -106,6 +110,11 @@
   },
   "application/atomicmail": {
     "source": "iana"
+  },
+  "application/atomserv+xml": {
+    "source": "mime-support",
+    "compressible": true,
+    "extensions": ["atomsrv"]
   },
   "application/atomsvc+xml": {
     "source": "iana",
@@ -148,7 +157,12 @@
   "application/batch-smtp": {
     "source": "iana"
   },
+  "application/bbolin": {
+    "source": "mime-support",
+    "extensions": ["lin"]
+  },
   "application/bdoc": {
+    "source": "custom",
     "compressible": false,
     "extensions": ["bdoc"]
   },
@@ -309,6 +323,7 @@
     "source": "iana"
   },
   "application/dart": {
+    "source": "custom",
     "compressible": true
   },
   "application/dash+xml": {
@@ -338,7 +353,8 @@
     "compressible": true
   },
   "application/dicom": {
-    "source": "iana"
+    "source": "iana",
+    "extensions": ["dcm"]
   },
   "application/dicom+json": {
     "source": "iana",
@@ -375,6 +391,10 @@
   "application/dskpp+xml": {
     "source": "iana",
     "compressible": true
+  },
+  "application/dsptype": {
+    "source": "mime-support",
+    "extensions": ["tsp"]
   },
   "application/dssc+der": {
     "source": "iana",
@@ -493,6 +513,7 @@
     "compressible": true
   },
   "application/fido.trusted-apps+json": {
+    "source": "custom",
     "compressible": true
   },
   "application/fits": {
@@ -502,7 +523,8 @@
     "source": "iana"
   },
   "application/font-sfnt": {
-    "source": "iana"
+    "source": "iana",
+    "extensions": ["otf","ttf"]
   },
   "application/font-tdpfr": {
     "source": "iana",
@@ -510,11 +532,16 @@
   },
   "application/font-woff": {
     "source": "iana",
-    "compressible": false
+    "compressible": false,
+    "extensions": ["woff"]
   },
   "application/framework-attributes+xml": {
     "source": "iana",
     "compressible": true
+  },
+  "application/futuresplash": {
+    "source": "mime-support",
+    "extensions": ["spl"]
   },
   "application/geo+json": {
     "source": "iana",
@@ -530,6 +557,9 @@
   "application/geoxacml+xml": {
     "source": "iana",
     "compressible": true
+  },
+  "application/ghostview": {
+    "source": "mime-support"
   },
   "application/gltf-buffer": {
     "source": "iana"
@@ -561,7 +591,12 @@
     "compressible": true
   },
   "application/hjson": {
+    "source": "custom",
     "extensions": ["hjson"]
+  },
+  "application/hta": {
+    "source": "mime-support",
+    "extensions": ["hta"]
   },
   "application/http": {
     "source": "iana"
@@ -677,6 +712,7 @@
     "source": "iana"
   },
   "application/json5": {
+    "source": "custom",
     "extensions": ["json5"]
   },
   "application/jsonml+json": {
@@ -736,6 +772,10 @@
   "application/lxf": {
     "source": "iana"
   },
+  "application/m3g": {
+    "source": "mime-support",
+    "extensions": ["m3g"]
+  },
   "application/mac-binhex40": {
     "source": "iana",
     "extensions": ["hqx"]
@@ -753,6 +793,7 @@
     "extensions": ["mads"]
   },
   "application/manifest+json": {
+    "source": "custom",
     "charset": "UTF-8",
     "compressible": true,
     "extensions": ["webmanifest"]
@@ -768,7 +809,7 @@
   },
   "application/mathematica": {
     "source": "iana",
-    "extensions": ["ma","nb","mb"]
+    "extensions": ["ma","nb","mb","nbp"]
   },
   "application/mathml+xml": {
     "source": "iana",
@@ -926,6 +967,13 @@
     "compressible": true,
     "extensions": ["xdf"]
   },
+  "application/ms-tnef": {
+    "source": "mime-support"
+  },
+  "application/msaccess": {
+    "source": "mime-support",
+    "extensions": ["mdb"]
+  },
   "application/msc-ivr+xml": {
     "source": "iana",
     "charset": "UTF-8",
@@ -971,6 +1019,9 @@
     "source": "iana",
     "charset": "US-ASCII"
   },
+  "application/news-message-id": {
+    "source": "mime-support"
+  },
   "application/news-transmission": {
     "source": "iana"
   },
@@ -994,7 +1045,7 @@
   "application/octet-stream": {
     "source": "iana",
     "compressible": false,
-    "extensions": ["bin","dms","lrf","mar","so","dist","distz","pkg","bpk","dump","elc","deploy","exe","dll","deb","dmg","iso","img","msi","msp","msm","buffer"]
+    "extensions": ["bin","dms","lrf","mar","so","dist","distz","pkg","bpk","dump","elc","deploy","exe","dll","deb","dmg","iso","img","msi","msp","msm","msu","buffer"]
   },
   "application/oda": {
     "source": "iana",
@@ -1024,7 +1075,7 @@
   },
   "application/onenote": {
     "source": "apache",
-    "extensions": ["onetoc","onetoc2","onetmp","onepkg"]
+    "extensions": ["onetoc","onetoc2","onetmp","onepkg","one"]
   },
   "application/oscore": {
     "source": "iana"
@@ -1066,7 +1117,8 @@
     "extensions": ["pgp"]
   },
   "application/pgp-keys": {
-    "source": "iana"
+    "source": "iana",
+    "extensions": ["key"]
   },
   "application/pgp-signature": {
     "source": "iana",
@@ -1141,7 +1193,7 @@
   "application/postscript": {
     "source": "iana",
     "compressible": true,
-    "extensions": ["ai","eps","ps"]
+    "extensions": ["ai","eps","ps","epsi","epsf","eps2","eps3"]
   },
   "application/ppsp-tracker+json": {
     "source": "iana",
@@ -1197,11 +1249,16 @@
     "source": "iana"
   },
   "application/raml+yaml": {
+    "source": "custom",
     "compressible": true,
     "extensions": ["raml"]
   },
   "application/raptorfec": {
     "source": "iana"
+  },
+  "application/rar": {
+    "source": "mime-support",
+    "extensions": ["rar"]
   },
   "application/rdap+json": {
     "source": "iana",
@@ -1444,6 +1501,10 @@
   "application/sipc": {
     "source": "iana"
   },
+  "application/sla": {
+    "source": "mime-support",
+    "extensions": ["stl"]
+  },
   "application/slate": {
     "source": "iana"
   },
@@ -1548,6 +1609,7 @@
     "source": "iana"
   },
   "application/tar": {
+    "source": "custom",
     "compressible": true
   },
   "application/taxii+json": {
@@ -1592,6 +1654,7 @@
     "source": "iana"
   },
   "application/toml": {
+    "source": "custom",
     "compressible": true,
     "extensions": ["toml"]
   },
@@ -1616,6 +1679,7 @@
     "source": "iana"
   },
   "application/ubjson": {
+    "source": "custom",
     "compressible": false,
     "extensions": ["ubj"]
   },
@@ -2028,6 +2092,7 @@
     "extensions": ["pages"]
   },
   "application/vnd.apple.pkpass": {
+    "source": "custom",
     "compressible": false,
     "extensions": ["pkpass"]
   },
@@ -2240,6 +2305,9 @@
     "source": "iana",
     "extensions": ["csp"]
   },
+  "application/vnd.comsocaller": {
+    "source": "mime-support"
+  },
   "application/vnd.contact.cmsg": {
     "source": "iana",
     "extensions": ["cdbcmsg"]
@@ -2351,7 +2419,8 @@
     "source": "iana"
   },
   "application/vnd.debian.binary-package": {
-    "source": "iana"
+    "source": "iana",
+    "extensions": ["deb","ddeb","udeb"]
   },
   "application/vnd.dece.data": {
     "source": "iana",
@@ -2746,7 +2815,8 @@
     "extensions": ["ftc"]
   },
   "application/vnd.font-fontforge-sfd": {
-    "source": "iana"
+    "source": "iana",
+    "extensions": ["sfd"]
   },
   "application/vnd.framemaker": {
     "source": "iana",
@@ -2876,14 +2946,17 @@
     "extensions": ["gmx"]
   },
   "application/vnd.google-apps.document": {
+    "source": "custom",
     "compressible": false,
     "extensions": ["gdoc"]
   },
   "application/vnd.google-apps.presentation": {
+    "source": "custom",
     "compressible": false,
     "extensions": ["gslides"]
   },
   "application/vnd.google-apps.spreadsheet": {
+    "source": "custom",
     "compressible": false,
     "extensions": ["gsheet"]
   },
@@ -3535,7 +3608,7 @@
   "application/vnd.ms-excel": {
     "source": "iana",
     "compressible": false,
-    "extensions": ["xls","xlm","xla","xlc","xlt","xlw"]
+    "extensions": ["xls","xlm","xla","xlc","xlt","xlw","xlb"]
   },
   "application/vnd.ms-excel.addin.macroenabled.12": {
     "source": "iana",
@@ -3583,6 +3656,7 @@
     "compressible": true
   },
   "application/vnd.ms-outlook": {
+    "source": "custom",
     "compressible": false,
     "extensions": ["msg"]
   },
@@ -4900,6 +4974,10 @@
     "source": "apache",
     "extensions": ["sdc"]
   },
+  "application/vnd.stardivision.chart": {
+    "source": "mime-support",
+    "extensions": ["sds"]
+  },
   "application/vnd.stardivision.draw": {
     "source": "apache",
     "extensions": ["sda"]
@@ -4910,7 +4988,7 @@
   },
   "application/vnd.stardivision.math": {
     "source": "apache",
-    "extensions": ["smf"]
+    "extensions": ["smf","sdf"]
   },
   "application/vnd.stardivision.writer": {
     "source": "apache",
@@ -5076,6 +5154,9 @@
   "application/vnd.truedoc": {
     "source": "iana"
   },
+  "application/vnd.tve-trigger": {
+    "source": "mime-support"
+  },
   "application/vnd.ubisoft.webplayer": {
     "source": "iana"
   },
@@ -5238,6 +5319,10 @@
     "source": "iana",
     "extensions": ["wpd"]
   },
+  "application/vnd.wordperfect5.1": {
+    "source": "mime-support",
+    "extensions": ["wp5"]
+  },
   "application/vnd.wqd": {
     "source": "iana",
     "extensions": ["wqd"]
@@ -5364,6 +5449,7 @@
     "source": "iana"
   },
   "application/wasm": {
+    "source": "mime-support",
     "compressible": true,
     "extensions": ["wasm"]
   },
@@ -5405,6 +5491,10 @@
     "compressible": true,
     "extensions": ["wspolicy"]
   },
+  "application/x-123": {
+    "source": "mime-support",
+    "extensions": ["wk"]
+  },
   "application/x-7z-compressed": {
     "source": "apache",
     "compressible": false,
@@ -5426,6 +5516,7 @@
     "extensions": ["dmg"]
   },
   "application/x-arj": {
+    "source": "custom",
     "compressible": false,
     "extensions": ["arj"]
   },
@@ -5446,6 +5537,7 @@
     "extensions": ["bcpio"]
   },
   "application/x-bdoc": {
+    "source": "custom",
     "compressible": false,
     "extensions": ["bdoc"]
   },
@@ -5467,9 +5559,21 @@
     "compressible": false,
     "extensions": ["bz2","boz"]
   },
+  "application/x-cab": {
+    "source": "mime-support",
+    "extensions": ["cab"]
+  },
   "application/x-cbr": {
     "source": "apache",
     "extensions": ["cbr","cba","cbt","cbz","cb7"]
+  },
+  "application/x-cbz": {
+    "source": "mime-support",
+    "extensions": ["cbz"]
+  },
+  "application/x-cdf": {
+    "source": "mime-support",
+    "extensions": ["cdf","cda"]
   },
   "application/x-cdlink": {
     "source": "apache",
@@ -5488,6 +5592,7 @@
     "extensions": ["pgn"]
   },
   "application/x-chrome-extension": {
+    "source": "custom",
     "extensions": ["crx"]
   },
   "application/x-cocoa": {
@@ -5497,9 +5602,16 @@
   "application/x-compress": {
     "source": "apache"
   },
+  "application/x-comsol": {
+    "source": "mime-support",
+    "extensions": ["mph"]
+  },
   "application/x-conference": {
     "source": "apache",
     "extensions": ["nsc"]
+  },
+  "application/x-core": {
+    "source": "mime-support"
   },
   "application/x-cpio": {
     "source": "apache",
@@ -5510,6 +5622,7 @@
     "extensions": ["csh"]
   },
   "application/x-deb": {
+    "source": "custom",
     "compressible": false
   },
   "application/x-debian-package": {
@@ -5523,6 +5636,10 @@
   "application/x-director": {
     "source": "apache",
     "extensions": ["dir","dcr","dxr","cst","cct","cxt","w3d","fgd","swa"]
+  },
+  "application/x-dms": {
+    "source": "mime-support",
+    "extensions": ["dms"]
   },
   "application/x-doom": {
     "source": "apache",
@@ -5555,6 +5672,13 @@
   "application/x-eva": {
     "source": "apache",
     "extensions": ["eva"]
+  },
+  "application/x-executable": {
+    "source": "mime-support"
+  },
+  "application/x-font": {
+    "source": "mime-support",
+    "extensions": ["pfa","pfb","gsf"]
   },
   "application/x-font-bdf": {
     "source": "apache",
@@ -5602,9 +5726,17 @@
     "source": "apache",
     "extensions": ["arc"]
   },
+  "application/x-freemind": {
+    "source": "mime-support",
+    "extensions": ["mm"]
+  },
   "application/x-futuresplash": {
     "source": "apache",
     "extensions": ["spl"]
+  },
+  "application/x-ganttproject": {
+    "source": "mime-support",
+    "extensions": ["gan"]
   },
   "application/x-gca-compressed": {
     "source": "apache",
@@ -5618,13 +5750,25 @@
     "source": "apache",
     "extensions": ["gnumeric"]
   },
+  "application/x-go-sgf": {
+    "source": "mime-support",
+    "extensions": ["sgf"]
+  },
   "application/x-gramps-xml": {
     "source": "apache",
     "extensions": ["gramps"]
   },
+  "application/x-graphing-calculator": {
+    "source": "mime-support",
+    "extensions": ["gcf"]
+  },
   "application/x-gtar": {
     "source": "apache",
     "extensions": ["gtar"]
+  },
+  "application/x-gtar-compressed": {
+    "source": "mime-support",
+    "extensions": ["tgz","taz"]
   },
   "application/x-gzip": {
     "source": "apache"
@@ -5634,20 +5778,51 @@
     "extensions": ["hdf"]
   },
   "application/x-httpd-php": {
+    "source": "custom",
     "compressible": true,
     "extensions": ["php"]
+  },
+  "application/x-hwp": {
+    "source": "mime-support",
+    "extensions": ["hwp"]
+  },
+  "application/x-ica": {
+    "source": "mime-support",
+    "extensions": ["ica"]
+  },
+  "application/x-info": {
+    "source": "mime-support",
+    "extensions": ["info"]
   },
   "application/x-install-instructions": {
     "source": "apache",
     "extensions": ["install"]
   },
+  "application/x-internet-signup": {
+    "source": "mime-support",
+    "extensions": ["ins","isp"]
+  },
+  "application/x-iphone": {
+    "source": "mime-support",
+    "extensions": ["iii"]
+  },
   "application/x-iso9660-image": {
     "source": "apache",
     "extensions": ["iso"]
   },
+  "application/x-jam": {
+    "source": "mime-support",
+    "extensions": ["jam"]
+  },
+  "application/x-java-applet": {
+    "source": "mime-support"
+  },
   "application/x-java-archive-diff": {
     "source": "nginx",
     "extensions": ["jardiff"]
+  },
+  "application/x-java-bean": {
+    "source": "mime-support"
   },
   "application/x-java-jnlp-file": {
     "source": "apache",
@@ -5655,22 +5830,76 @@
     "extensions": ["jnlp"]
   },
   "application/x-javascript": {
+    "source": "custom",
     "compressible": true
   },
+  "application/x-jmol": {
+    "source": "mime-support",
+    "extensions": ["jmz"]
+  },
+  "application/x-kchart": {
+    "source": "mime-support",
+    "extensions": ["chrt"]
+  },
+  "application/x-kdelnk": {
+    "source": "mime-support"
+  },
   "application/x-keepass2": {
+    "source": "custom",
     "extensions": ["kdbx"]
+  },
+  "application/x-killustrator": {
+    "source": "mime-support",
+    "extensions": ["kil"]
+  },
+  "application/x-koan": {
+    "source": "mime-support",
+    "extensions": ["skp","skd","skt","skm"]
+  },
+  "application/x-kpresenter": {
+    "source": "mime-support",
+    "extensions": ["kpr","kpt"]
+  },
+  "application/x-kspread": {
+    "source": "mime-support",
+    "extensions": ["ksp"]
+  },
+  "application/x-kword": {
+    "source": "mime-support",
+    "extensions": ["kwd","kwt"]
   },
   "application/x-latex": {
     "source": "apache",
     "compressible": false,
     "extensions": ["latex"]
   },
+  "application/x-lha": {
+    "source": "mime-support",
+    "extensions": ["lha"]
+  },
   "application/x-lua-bytecode": {
+    "source": "custom",
     "extensions": ["luac"]
+  },
+  "application/x-lyx": {
+    "source": "mime-support",
+    "extensions": ["lyx"]
+  },
+  "application/x-lzh": {
+    "source": "mime-support",
+    "extensions": ["lzh"]
   },
   "application/x-lzh-compressed": {
     "source": "apache",
     "extensions": ["lzh","lha"]
+  },
+  "application/x-lzx": {
+    "source": "mime-support",
+    "extensions": ["lzx"]
+  },
+  "application/x-maker": {
+    "source": "mime-support",
+    "extensions": ["frm","maker","frame","fm","fb","book","fbdoc"]
   },
   "application/x-makeself": {
     "source": "nginx",
@@ -5680,16 +5909,26 @@
     "source": "apache",
     "extensions": ["mie"]
   },
+  "application/x-mif": {
+    "source": "mime-support",
+    "extensions": ["mif"]
+  },
   "application/x-mobipocket-ebook": {
     "source": "apache",
     "extensions": ["prc","mobi"]
   },
   "application/x-mpegurl": {
-    "compressible": false
+    "source": "mime-support",
+    "compressible": false,
+    "extensions": ["m3u8"]
   },
   "application/x-ms-application": {
     "source": "apache",
     "extensions": ["application"]
+  },
+  "application/x-ms-manifest": {
+    "source": "mime-support",
+    "extensions": ["manifest"]
   },
   "application/x-ms-shortcut": {
     "source": "apache",
@@ -5724,11 +5963,16 @@
     "extensions": ["clp"]
   },
   "application/x-msdos-program": {
-    "extensions": ["exe"]
+    "source": "mime-support",
+    "extensions": ["com","exe","bat","dll"]
   },
   "application/x-msdownload": {
     "source": "apache",
     "extensions": ["exe","dll","com","bat","msi"]
+  },
+  "application/x-msi": {
+    "source": "mime-support",
+    "extensions": ["msi"]
   },
   "application/x-msmediaview": {
     "source": "apache",
@@ -5763,12 +6007,25 @@
     "extensions": ["nc","cdf"]
   },
   "application/x-ns-proxy-autoconfig": {
+    "source": "mime-support",
     "compressible": true,
     "extensions": ["pac"]
+  },
+  "application/x-nwc": {
+    "source": "mime-support",
+    "extensions": ["nwc"]
   },
   "application/x-nzb": {
     "source": "apache",
     "extensions": ["nzb"]
+  },
+  "application/x-object": {
+    "source": "mime-support",
+    "extensions": ["o"]
+  },
+  "application/x-oz-application": {
+    "source": "mime-support",
+    "extensions": ["oza"]
   },
   "application/x-perl": {
     "source": "nginx",
@@ -5791,13 +6048,33 @@
     "source": "apache",
     "extensions": ["p7r"]
   },
+  "application/x-pkcs7-crl": {
+    "source": "mime-support",
+    "extensions": ["crl"]
+  },
   "application/x-pki-message": {
     "source": "iana"
+  },
+  "application/x-python-code": {
+    "source": "mime-support",
+    "extensions": ["pyc","pyo"]
+  },
+  "application/x-qgis": {
+    "source": "mime-support",
+    "extensions": ["qgs","shp","shx"]
+  },
+  "application/x-quicktimeplayer": {
+    "source": "mime-support",
+    "extensions": ["qtl"]
   },
   "application/x-rar-compressed": {
     "source": "apache",
     "compressible": false,
     "extensions": ["rar"]
+  },
+  "application/x-rdp": {
+    "source": "mime-support",
+    "extensions": ["rdp"]
   },
   "application/x-redhat-package-manager": {
     "source": "nginx",
@@ -5806,6 +6083,26 @@
   "application/x-research-info-systems": {
     "source": "apache",
     "extensions": ["ris"]
+  },
+  "application/x-rss+xml": {
+    "source": "mime-support",
+    "compressible": true,
+    "extensions": ["rss"]
+  },
+  "application/x-ruby": {
+    "source": "mime-support",
+    "extensions": ["rb"]
+  },
+  "application/x-rx": {
+    "source": "mime-support"
+  },
+  "application/x-scilab": {
+    "source": "mime-support",
+    "extensions": ["sci","sce"]
+  },
+  "application/x-scilab-xcos": {
+    "source": "mime-support",
+    "extensions": ["xcos"]
   },
   "application/x-sea": {
     "source": "nginx",
@@ -5820,10 +6117,17 @@
     "source": "apache",
     "extensions": ["shar"]
   },
+  "application/x-shellscript": {
+    "source": "mime-support"
+  },
   "application/x-shockwave-flash": {
     "source": "apache",
     "compressible": false,
-    "extensions": ["swf"]
+    "extensions": ["swf","swfl"]
+  },
+  "application/x-silverlight": {
+    "source": "mime-support",
+    "extensions": ["scr"]
   },
   "application/x-silverlight-app": {
     "source": "apache",
@@ -5836,7 +6140,7 @@
   "application/x-stuffit": {
     "source": "apache",
     "compressible": false,
-    "extensions": ["sit"]
+    "extensions": ["sit","sitx"]
   },
   "application/x-stuffitx": {
     "source": "apache",
@@ -5875,6 +6179,14 @@
     "source": "apache",
     "extensions": ["tex"]
   },
+  "application/x-tex-gf": {
+    "source": "mime-support",
+    "extensions": ["gf"]
+  },
+  "application/x-tex-pk": {
+    "source": "mime-support",
+    "extensions": ["pk"]
+  },
   "application/x-tex-tfm": {
     "source": "apache",
     "extensions": ["tfm"]
@@ -5887,39 +6199,66 @@
     "source": "apache",
     "extensions": ["obj"]
   },
+  "application/x-troff": {
+    "source": "mime-support",
+    "extensions": ["t","tr","roff"]
+  },
+  "application/x-troff-man": {
+    "source": "mime-support",
+    "extensions": ["man"]
+  },
+  "application/x-troff-me": {
+    "source": "mime-support",
+    "extensions": ["me"]
+  },
+  "application/x-troff-ms": {
+    "source": "mime-support",
+    "extensions": ["ms"]
+  },
   "application/x-ustar": {
     "source": "apache",
     "extensions": ["ustar"]
   },
+  "application/x-videolan": {
+    "source": "mime-support"
+  },
   "application/x-virtualbox-hdd": {
+    "source": "custom",
     "compressible": true,
     "extensions": ["hdd"]
   },
   "application/x-virtualbox-ova": {
+    "source": "custom",
     "compressible": true,
     "extensions": ["ova"]
   },
   "application/x-virtualbox-ovf": {
+    "source": "custom",
     "compressible": true,
     "extensions": ["ovf"]
   },
   "application/x-virtualbox-vbox": {
+    "source": "custom",
     "compressible": true,
     "extensions": ["vbox"]
   },
   "application/x-virtualbox-vbox-extpack": {
+    "source": "custom",
     "compressible": false,
     "extensions": ["vbox-extpack"]
   },
   "application/x-virtualbox-vdi": {
+    "source": "custom",
     "compressible": true,
     "extensions": ["vdi"]
   },
   "application/x-virtualbox-vhd": {
+    "source": "custom",
     "compressible": true,
     "extensions": ["vhd"]
   },
   "application/x-virtualbox-vmdk": {
+    "source": "custom",
     "compressible": true,
     "extensions": ["vmdk"]
   },
@@ -5928,8 +6267,13 @@
     "extensions": ["src"]
   },
   "application/x-web-app-manifest+json": {
+    "source": "custom",
     "compressible": true,
     "extensions": ["webapp"]
+  },
+  "application/x-wingz": {
+    "source": "mime-support",
+    "extensions": ["wz"]
   },
   "application/x-www-form-urlencoded": {
     "source": "iana",
@@ -5944,6 +6288,10 @@
   },
   "application/x-x509-next-ca-cert": {
     "source": "iana"
+  },
+  "application/x-xcf": {
+    "source": "mime-support",
+    "extensions": ["xcf"]
   },
   "application/x-xfig": {
     "source": "apache",
@@ -6070,7 +6418,7 @@
   "application/xslt+xml": {
     "source": "iana",
     "compressible": true,
-    "extensions": ["xslt"]
+    "extensions": ["xslt","xsl"]
   },
   "application/xspf+xml": {
     "source": "apache",
@@ -6143,13 +6491,19 @@
     "extensions": ["adp"]
   },
   "audio/amr": {
-    "source": "iana"
+    "source": "iana",
+    "extensions": ["amr"]
   },
   "audio/amr-wb": {
-    "source": "iana"
+    "source": "iana",
+    "extensions": ["awb"]
   },
   "audio/amr-wb+": {
     "source": "iana"
+  },
+  "audio/annodex": {
+    "source": "mime-support",
+    "extensions": ["axa"]
   },
   "audio/aptx": {
     "source": "iana"
@@ -6182,6 +6536,10 @@
   },
   "audio/cn": {
     "source": "iana"
+  },
+  "audio/csound": {
+    "source": "mime-support",
+    "extensions": ["csd","orc","sco"]
   },
   "audio/dat12": {
     "source": "iana"
@@ -6255,11 +6613,18 @@
   "audio/evs": {
     "source": "iana"
   },
+  "audio/flac": {
+    "source": "mime-support",
+    "extensions": ["flac"]
+  },
   "audio/flexfec": {
     "source": "iana"
   },
   "audio/fwdred": {
     "source": "iana"
+  },
+  "audio/g.722.1": {
+    "source": "mime-support"
   },
   "audio/g711-0": {
     "source": "iana"
@@ -6361,6 +6726,7 @@
     "extensions": ["mxmf"]
   },
   "audio/mp3": {
+    "source": "custom",
     "compressible": false,
     "extensions": ["mp3"]
   },
@@ -6381,10 +6747,14 @@
   "audio/mpeg": {
     "source": "iana",
     "compressible": false,
-    "extensions": ["mpga","mp2","mp2a","mp3","m2a","m3a"]
+    "extensions": ["mpga","mp2","mp2a","mp3","m2a","m3a","mpega","m4a"]
   },
   "audio/mpeg4-generic": {
     "source": "iana"
+  },
+  "audio/mpegurl": {
+    "source": "mime-support",
+    "extensions": ["m3u"]
   },
   "audio/musepack": {
     "source": "apache"
@@ -6392,7 +6762,7 @@
   "audio/ogg": {
     "source": "iana",
     "compressible": false,
-    "extensions": ["oga","ogg","spx"]
+    "extensions": ["oga","ogg","spx","opus"]
   },
   "audio/opus": {
     "source": "iana"
@@ -6413,7 +6783,8 @@
     "source": "iana"
   },
   "audio/prs.sid": {
-    "source": "iana"
+    "source": "iana",
+    "extensions": ["sid"]
   },
   "audio/qcelp": {
     "source": "iana"
@@ -6624,6 +6995,7 @@
     "extensions": ["rip"]
   },
   "audio/vnd.rn-realaudio": {
+    "source": "custom",
     "compressible": false
   },
   "audio/vnd.sealedmedia.softseal.mpeg": {
@@ -6633,6 +7005,7 @@
     "source": "iana"
   },
   "audio/vnd.wave": {
+    "source": "custom",
     "compressible": false
   },
   "audio/vorbis": {
@@ -6643,10 +7016,12 @@
     "source": "iana"
   },
   "audio/wav": {
+    "source": "custom",
     "compressible": false,
     "extensions": ["wav"]
   },
   "audio/wave": {
+    "source": "custom",
     "compressible": false,
     "extensions": ["wav"]
   },
@@ -6673,6 +7048,10 @@
     "source": "apache",
     "extensions": ["flac"]
   },
+  "audio/x-gsm": {
+    "source": "mime-support",
+    "extensions": ["gsm"]
+  },
   "audio/x-m4a": {
     "source": "nginx",
     "extensions": ["m4a"]
@@ -6695,7 +7074,7 @@
   },
   "audio/x-pn-realaudio": {
     "source": "apache",
-    "extensions": ["ram","ra"]
+    "extensions": ["ram","ra","rm"]
   },
   "audio/x-pn-realaudio-plugin": {
     "source": "apache",
@@ -6704,6 +7083,14 @@
   "audio/x-realaudio": {
     "source": "nginx",
     "extensions": ["ra"]
+  },
+  "audio/x-scpls": {
+    "source": "mime-support",
+    "extensions": ["pls"]
+  },
+  "audio/x-sd2": {
+    "source": "mime-support",
+    "extensions": ["sd2"]
   },
   "audio/x-tta": {
     "source": "apache"
@@ -6716,9 +7103,37 @@
     "source": "apache",
     "extensions": ["xm"]
   },
+  "chemical/x-alchemy": {
+    "source": "mime-support",
+    "extensions": ["alc"]
+  },
+  "chemical/x-cache": {
+    "source": "mime-support",
+    "extensions": ["cac","cache"]
+  },
+  "chemical/x-cache-csf": {
+    "source": "mime-support",
+    "extensions": ["csf"]
+  },
+  "chemical/x-cactvs-binary": {
+    "source": "mime-support",
+    "extensions": ["cbin","cascii","ctab"]
+  },
   "chemical/x-cdx": {
     "source": "apache",
     "extensions": ["cdx"]
+  },
+  "chemical/x-cerius": {
+    "source": "mime-support",
+    "extensions": ["cer"]
+  },
+  "chemical/x-chem3d": {
+    "source": "mime-support",
+    "extensions": ["c3d"]
+  },
+  "chemical/x-chemdraw": {
+    "source": "mime-support",
+    "extensions": ["chm"]
   },
   "chemical/x-cif": {
     "source": "apache",
@@ -6732,12 +7147,173 @@
     "source": "apache",
     "extensions": ["cml"]
   },
+  "chemical/x-compass": {
+    "source": "mime-support",
+    "extensions": ["cpa"]
+  },
+  "chemical/x-crossfire": {
+    "source": "mime-support",
+    "extensions": ["bsd"]
+  },
   "chemical/x-csml": {
     "source": "apache",
-    "extensions": ["csml"]
+    "extensions": ["csml","csm"]
+  },
+  "chemical/x-ctx": {
+    "source": "mime-support",
+    "extensions": ["ctx"]
+  },
+  "chemical/x-cxf": {
+    "source": "mime-support",
+    "extensions": ["cxf","cef"]
+  },
+  "chemical/x-embl-dl-nucleotide": {
+    "source": "mime-support",
+    "extensions": ["emb","embl"]
+  },
+  "chemical/x-galactic-spc": {
+    "source": "mime-support",
+    "extensions": ["spc"]
+  },
+  "chemical/x-gamess-input": {
+    "source": "mime-support",
+    "extensions": ["inp","gam","gamin"]
+  },
+  "chemical/x-gaussian-checkpoint": {
+    "source": "mime-support",
+    "extensions": ["fch","fchk"]
+  },
+  "chemical/x-gaussian-cube": {
+    "source": "mime-support",
+    "extensions": ["cub"]
+  },
+  "chemical/x-gaussian-input": {
+    "source": "mime-support",
+    "extensions": ["gau","gjc","gjf"]
+  },
+  "chemical/x-gaussian-log": {
+    "source": "mime-support",
+    "extensions": ["gal"]
+  },
+  "chemical/x-gcg8-sequence": {
+    "source": "mime-support",
+    "extensions": ["gcg"]
+  },
+  "chemical/x-genbank": {
+    "source": "mime-support",
+    "extensions": ["gen"]
+  },
+  "chemical/x-hin": {
+    "source": "mime-support",
+    "extensions": ["hin"]
+  },
+  "chemical/x-isostar": {
+    "source": "mime-support",
+    "extensions": ["istr","ist"]
+  },
+  "chemical/x-jcamp-dx": {
+    "source": "mime-support",
+    "extensions": ["jdx","dx"]
+  },
+  "chemical/x-kinemage": {
+    "source": "mime-support",
+    "extensions": ["kin"]
+  },
+  "chemical/x-macmolecule": {
+    "source": "mime-support",
+    "extensions": ["mcm"]
+  },
+  "chemical/x-macromodel-input": {
+    "source": "mime-support",
+    "extensions": ["mmd","mmod"]
+  },
+  "chemical/x-mdl-molfile": {
+    "source": "mime-support",
+    "extensions": ["mol"]
+  },
+  "chemical/x-mdl-rdfile": {
+    "source": "mime-support",
+    "extensions": ["rd"]
+  },
+  "chemical/x-mdl-rxnfile": {
+    "source": "mime-support",
+    "extensions": ["rxn"]
+  },
+  "chemical/x-mdl-sdfile": {
+    "source": "mime-support",
+    "extensions": ["sd","sdf"]
+  },
+  "chemical/x-mdl-tgf": {
+    "source": "mime-support",
+    "extensions": ["tgf"]
+  },
+  "chemical/x-mmcif": {
+    "source": "mime-support",
+    "extensions": ["mcif"]
+  },
+  "chemical/x-mol2": {
+    "source": "mime-support",
+    "extensions": ["mol2"]
+  },
+  "chemical/x-molconn-z": {
+    "source": "mime-support",
+    "extensions": ["b"]
+  },
+  "chemical/x-mopac-graph": {
+    "source": "mime-support",
+    "extensions": ["gpt"]
+  },
+  "chemical/x-mopac-input": {
+    "source": "mime-support",
+    "extensions": ["mop","mopcrt","mpc","zmt"]
+  },
+  "chemical/x-mopac-out": {
+    "source": "mime-support",
+    "extensions": ["moo"]
+  },
+  "chemical/x-mopac-vib": {
+    "source": "mime-support",
+    "extensions": ["mvb"]
+  },
+  "chemical/x-ncbi-asn1": {
+    "source": "mime-support",
+    "extensions": ["asn"]
+  },
+  "chemical/x-ncbi-asn1-ascii": {
+    "source": "mime-support",
+    "extensions": ["prt","ent"]
+  },
+  "chemical/x-ncbi-asn1-binary": {
+    "source": "mime-support",
+    "extensions": ["val","aso"]
+  },
+  "chemical/x-ncbi-asn1-spec": {
+    "source": "mime-support",
+    "extensions": ["asn"]
   },
   "chemical/x-pdb": {
-    "source": "apache"
+    "source": "apache",
+    "extensions": ["pdb","ent"]
+  },
+  "chemical/x-rosdal": {
+    "source": "mime-support",
+    "extensions": ["ros"]
+  },
+  "chemical/x-swissprot": {
+    "source": "mime-support",
+    "extensions": ["sw"]
+  },
+  "chemical/x-vamas-iso14976": {
+    "source": "mime-support",
+    "extensions": ["vms"]
+  },
+  "chemical/x-vmd": {
+    "source": "mime-support",
+    "extensions": ["vmd"]
+  },
+  "chemical/x-xtel": {
+    "source": "mime-support",
+    "extensions": ["xtel"]
   },
   "chemical/x-xyz": {
     "source": "apache",
@@ -6750,15 +7326,16 @@
   "font/otf": {
     "source": "iana",
     "compressible": true,
-    "extensions": ["otf"]
+    "extensions": ["otf","ttf"]
   },
   "font/sfnt": {
-    "source": "iana"
+    "source": "iana",
+    "extensions": ["ttf","otf"]
   },
   "font/ttf": {
     "source": "iana",
     "compressible": true,
-    "extensions": ["ttf"]
+    "extensions": ["ttf","otf"]
   },
   "font/woff": {
     "source": "iana",
@@ -6773,6 +7350,7 @@
     "extensions": ["exr"]
   },
   "image/apng": {
+    "source": "custom",
     "compressible": false,
     "extensions": ["apng"]
   },
@@ -6783,6 +7361,7 @@
     "source": "iana"
   },
   "image/avif": {
+    "source": "custom",
     "compressible": false,
     "extensions": ["avif"]
   },
@@ -6911,7 +7490,12 @@
   "image/naplps": {
     "source": "iana"
   },
+  "image/pcx": {
+    "source": "mime-support",
+    "extensions": ["pcx"]
+  },
   "image/pjpeg": {
+    "source": "custom",
     "compressible": false
   },
   "image/png": {
@@ -7018,6 +7602,7 @@
     "source": "iana"
   },
   "image/vnd.ms-dds": {
+    "source": "custom",
     "extensions": ["dds"]
   },
   "image/vnd.ms-modi": {
@@ -7079,6 +7664,14 @@
     "source": "apache",
     "extensions": ["3ds"]
   },
+  "image/x-canon-cr2": {
+    "source": "mime-support",
+    "extensions": ["cr2"]
+  },
+  "image/x-canon-crw": {
+    "source": "mime-support",
+    "extensions": ["crw"]
+  },
   "image/x-cmu-raster": {
     "source": "apache",
     "extensions": ["ras"]
@@ -7086,6 +7679,26 @@
   "image/x-cmx": {
     "source": "apache",
     "extensions": ["cmx"]
+  },
+  "image/x-coreldraw": {
+    "source": "mime-support",
+    "extensions": ["cdr"]
+  },
+  "image/x-coreldrawpattern": {
+    "source": "mime-support",
+    "extensions": ["pat"]
+  },
+  "image/x-coreldrawtemplate": {
+    "source": "mime-support",
+    "extensions": ["cdt"]
+  },
+  "image/x-corelphotopaint": {
+    "source": "mime-support",
+    "extensions": ["cpt"]
+  },
+  "image/x-epson-erf": {
+    "source": "mime-support",
+    "extensions": ["erf"]
   },
   "image/x-freehand": {
     "source": "apache",
@@ -7095,6 +7708,10 @@
     "source": "apache",
     "compressible": true,
     "extensions": ["ico"]
+  },
+  "image/x-jg": {
+    "source": "mime-support",
+    "extensions": ["art"]
   },
   "image/x-jng": {
     "source": "nginx",
@@ -7109,9 +7726,21 @@
     "compressible": true,
     "extensions": ["bmp"]
   },
+  "image/x-nikon-nef": {
+    "source": "mime-support",
+    "extensions": ["nef"]
+  },
+  "image/x-olympus-orf": {
+    "source": "mime-support",
+    "extensions": ["orf"]
+  },
   "image/x-pcx": {
     "source": "apache",
     "extensions": ["pcx"]
+  },
+  "image/x-photoshop": {
+    "source": "mime-support",
+    "extensions": ["psd"]
   },
   "image/x-pict": {
     "source": "apache",
@@ -7146,6 +7775,7 @@
     "extensions": ["xbm"]
   },
   "image/x-xcf": {
+    "source": "custom",
     "compressible": false
   },
   "image/x-xpixmap": {
@@ -7155,6 +7785,24 @@
   "image/x-xwindowdump": {
     "source": "apache",
     "extensions": ["xwd"]
+  },
+  "inode/blockdevice": {
+    "source": "mime-support"
+  },
+  "inode/chardevice": {
+    "source": "mime-support"
+  },
+  "inode/directory": {
+    "source": "mime-support"
+  },
+  "inode/directory-locked": {
+    "source": "mime-support"
+  },
+  "inode/fifo": {
+    "source": "mime-support"
+  },
+  "inode/socket": {
+    "source": "mime-support"
   },
   "message/cpim": {
     "source": "iana"
@@ -7418,15 +8066,18 @@
   },
   "text/calendar": {
     "source": "iana",
-    "extensions": ["ics","ifb"]
+    "extensions": ["ics","ifb","icz"]
   },
   "text/calender": {
+    "source": "custom",
     "compressible": true
   },
   "text/cmd": {
+    "source": "custom",
     "compressible": true
   },
   "text/coffeescript": {
+    "source": "custom",
     "extensions": ["coffee","litcoffee"]
   },
   "text/css": {
@@ -7455,6 +8106,9 @@
   "text/encaprtp": {
     "source": "iana"
   },
+  "text/english": {
+    "source": "mime-support"
+  },
   "text/enriched": {
     "source": "iana"
   },
@@ -7467,12 +8121,21 @@
   "text/grammar-ref-list": {
     "source": "iana"
   },
+  "text/h323": {
+    "source": "mime-support",
+    "extensions": ["323"]
+  },
   "text/html": {
     "source": "iana",
     "compressible": true,
     "extensions": ["html","htm","shtml"]
   },
+  "text/iuls": {
+    "source": "mime-support",
+    "extensions": ["uls"]
+  },
   "text/jade": {
+    "source": "custom",
     "extensions": ["jade"]
   },
   "text/javascript": {
@@ -7483,23 +8146,26 @@
     "source": "iana"
   },
   "text/jsx": {
+    "source": "custom",
     "compressible": true,
     "extensions": ["jsx"]
   },
   "text/less": {
+    "source": "custom",
     "compressible": true,
     "extensions": ["less"]
   },
   "text/markdown": {
     "source": "iana",
     "compressible": true,
-    "extensions": ["markdown","md"]
+    "extensions": ["md","markdown"]
   },
   "text/mathml": {
     "source": "nginx",
     "extensions": ["mml"]
   },
   "text/mdx": {
+    "source": "custom",
     "compressible": true,
     "extensions": ["mdx"]
   },
@@ -7522,7 +8188,7 @@
   "text/plain": {
     "source": "iana",
     "compressible": true,
-    "extensions": ["txt","text","conf","def","list","log","in","ini"]
+    "extensions": ["txt","text","conf","def","list","log","in","asc","pot","brf","srt","ini"]
   },
   "text/provenance-notation": {
     "source": "iana",
@@ -7566,6 +8232,10 @@
   "text/rtx": {
     "source": "iana"
   },
+  "text/scriptlet": {
+    "source": "mime-support",
+    "extensions": ["sct","wsc"]
+  },
   "text/sgml": {
     "source": "iana",
     "extensions": ["sgml","sgm"]
@@ -7574,9 +8244,11 @@
     "source": "iana"
   },
   "text/shex": {
+    "source": "custom",
     "extensions": ["shex"]
   },
   "text/slim": {
+    "source": "custom",
     "extensions": ["slim","slm"]
   },
   "text/spdx": {
@@ -7587,6 +8259,7 @@
     "source": "iana"
   },
   "text/stylus": {
+    "source": "custom",
     "extensions": ["stylus","styl"]
   },
   "text/t140": {
@@ -7596,6 +8269,10 @@
     "source": "iana",
     "compressible": true,
     "extensions": ["tsv"]
+  },
+  "text/texmacs": {
+    "source": "mime-support",
+    "extensions": ["tm"]
   },
   "text/troff": {
     "source": "iana",
@@ -7617,7 +8294,7 @@
   "text/vcard": {
     "source": "iana",
     "compressible": true,
-    "extensions": ["vcard"]
+    "extensions": ["vcard","vcf"]
   },
   "text/vnd.a": {
     "source": "iana"
@@ -7661,6 +8338,9 @@
   },
   "text/vnd.ficlab.flt": {
     "source": "iana"
+  },
+  "text/vnd.flatland.3dml": {
+    "source": "mime-support"
   },
   "text/vnd.fly": {
     "source": "iana",
@@ -7751,37 +8431,96 @@
     "source": "apache",
     "extensions": ["s","asm"]
   },
+  "text/x-bibtex": {
+    "source": "mime-support",
+    "extensions": ["bib"]
+  },
+  "text/x-boo": {
+    "source": "mime-support",
+    "extensions": ["boo"]
+  },
   "text/x-c": {
     "source": "apache",
     "extensions": ["c","cc","cxx","cpp","h","hh","dic"]
   },
+  "text/x-chdr": {
+    "source": "mime-support",
+    "extensions": ["h"]
+  },
   "text/x-component": {
     "source": "nginx",
     "extensions": ["htc"]
+  },
+  "text/x-crontab": {
+    "source": "mime-support"
+  },
+  "text/x-csh": {
+    "source": "mime-support",
+    "extensions": ["csh"]
+  },
+  "text/x-csrc": {
+    "source": "mime-support",
+    "extensions": ["c"]
+  },
+  "text/x-diff": {
+    "source": "mime-support",
+    "extensions": ["diff","patch"]
+  },
+  "text/x-dsrc": {
+    "source": "mime-support",
+    "extensions": ["d"]
   },
   "text/x-fortran": {
     "source": "apache",
     "extensions": ["f","for","f77","f90"]
   },
   "text/x-gwt-rpc": {
+    "source": "custom",
     "compressible": true
   },
   "text/x-handlebars-template": {
+    "source": "custom",
     "extensions": ["hbs"]
+  },
+  "text/x-haskell": {
+    "source": "mime-support",
+    "extensions": ["hs"]
+  },
+  "text/x-java": {
+    "source": "mime-support",
+    "extensions": ["java"]
   },
   "text/x-java-source": {
     "source": "apache",
     "extensions": ["java"]
   },
   "text/x-jquery-tmpl": {
+    "source": "custom",
     "compressible": true
   },
+  "text/x-lilypond": {
+    "source": "mime-support",
+    "extensions": ["ly"]
+  },
+  "text/x-literate-haskell": {
+    "source": "mime-support",
+    "extensions": ["lhs"]
+  },
   "text/x-lua": {
+    "source": "custom",
     "extensions": ["lua"]
   },
+  "text/x-makefile": {
+    "source": "mime-support"
+  },
   "text/x-markdown": {
+    "source": "custom",
     "compressible": true,
     "extensions": ["mkd"]
+  },
+  "text/x-moc": {
+    "source": "mime-support",
+    "extensions": ["moc"]
   },
   "text/x-nfo": {
     "source": "apache",
@@ -7792,6 +8531,7 @@
     "extensions": ["opml"]
   },
   "text/x-org": {
+    "source": "custom",
     "compressible": true,
     "extensions": ["org"]
   },
@@ -7799,15 +8539,37 @@
     "source": "apache",
     "extensions": ["p","pas"]
   },
+  "text/x-pcs-gcd": {
+    "source": "mime-support",
+    "extensions": ["gcd"]
+  },
+  "text/x-perl": {
+    "source": "mime-support",
+    "extensions": ["pl","pm"]
+  },
   "text/x-processing": {
+    "source": "custom",
     "compressible": true,
     "extensions": ["pde"]
   },
+  "text/x-python": {
+    "source": "mime-support",
+    "extensions": ["py"]
+  },
   "text/x-sass": {
+    "source": "custom",
     "extensions": ["sass"]
   },
+  "text/x-scala": {
+    "source": "mime-support",
+    "extensions": ["scala"]
+  },
   "text/x-scss": {
+    "source": "custom",
     "extensions": ["scss"]
+  },
+  "text/x-server-parsed-html": {
+    "source": "mime-support"
   },
   "text/x-setext": {
     "source": "apache",
@@ -7817,9 +8579,22 @@
     "source": "apache",
     "extensions": ["sfv"]
   },
+  "text/x-sh": {
+    "source": "mime-support",
+    "extensions": ["sh"]
+  },
   "text/x-suse-ymp": {
+    "source": "custom",
     "compressible": true,
     "extensions": ["ymp"]
+  },
+  "text/x-tcl": {
+    "source": "mime-support",
+    "extensions": ["tcl","tk"]
+  },
+  "text/x-tex": {
+    "source": "mime-support",
+    "extensions": ["tex","ltx","sty","cls"]
   },
   "text/x-uuencode": {
     "source": "apache",
@@ -7842,6 +8617,7 @@
     "source": "iana"
   },
   "text/yaml": {
+    "source": "custom",
     "extensions": ["yaml","yml"]
   },
   "video/1d-interleaved-parityfec": {
@@ -7858,6 +8634,10 @@
     "source": "iana",
     "extensions": ["3g2"]
   },
+  "video/annodex": {
+    "source": "mime-support",
+    "extensions": ["axv"]
+  },
   "video/bmpeg": {
     "source": "iana"
   },
@@ -7867,14 +8647,27 @@
   "video/celb": {
     "source": "iana"
   },
+  "video/dl": {
+    "source": "mime-support",
+    "extensions": ["dl"]
+  },
   "video/dv": {
-    "source": "iana"
+    "source": "iana",
+    "extensions": ["dif","dv"]
   },
   "video/encaprtp": {
     "source": "iana"
   },
   "video/flexfec": {
     "source": "iana"
+  },
+  "video/fli": {
+    "source": "mime-support",
+    "extensions": ["fli"]
+  },
+  "video/gl": {
+    "source": "mime-support",
+    "extensions": ["gl"]
   },
   "video/h261": {
     "source": "iana",
@@ -8077,6 +8870,9 @@
     "source": "iana",
     "extensions": ["pyv"]
   },
+  "video/vnd.mts": {
+    "source": "mime-support"
+  },
   "video/vnd.nokia.interleaved-multimedia": {
     "source": "iana"
   },
@@ -8139,6 +8935,10 @@
     "compressible": false,
     "extensions": ["flv"]
   },
+  "video/x-la-asf": {
+    "source": "mime-support",
+    "extensions": ["lsf","lsx"]
+  },
   "video/x-m4v": {
     "source": "apache",
     "extensions": ["m4v"]
@@ -8146,7 +8946,7 @@
   "video/x-matroska": {
     "source": "apache",
     "compressible": false,
-    "extensions": ["mkv","mk3d","mks"]
+    "extensions": ["mkv","mk3d","mks","mpv"]
   },
   "video/x-mng": {
     "source": "apache",
@@ -8193,10 +8993,20 @@
     "source": "apache",
     "extensions": ["ice"]
   },
+  "x-epoc/x-sisx-app": {
+    "source": "mime-support",
+    "extensions": ["sisx"]
+  },
   "x-shader/x-fragment": {
+    "source": "custom",
     "compressible": true
   },
   "x-shader/x-vertex": {
+    "source": "custom",
     "compressible": true
+  },
+  "x-world/x-vrml": {
+    "source": "mime-support",
+    "extensions": ["vrm","vrml","wrl"]
   }
 }

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -10,6 +10,9 @@ addData(db, require('../src/apache-types.json'), 'apache')
 // add the mime extensions from nginx
 addData(db, require('../src/nginx-types.json'), 'nginx')
 
+// add the mime extensions from nginx
+addData(db, require('../src/mime-support-types.json'), 'mime-support')
+
 // now add all our custom data
 addData(db, require('../src/custom-types.json'), 'custom')
 

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -11,7 +11,7 @@ addData(db, require('../src/apache-types.json'), 'apache')
 addData(db, require('../src/nginx-types.json'), 'nginx')
 
 // now add all our custom data
-addData(db, require('../src/custom-types.json'))
+addData(db, require('../src/custom-types.json'), 'custom')
 
 // finally, all custom suffix defaults
 var mime = require('../src/custom-suffix.json')

--- a/scripts/fetch-mime-support.js
+++ b/scripts/fetch-mime-support.js
@@ -4,8 +4,8 @@ var getMimeTypes = require('./fetch-mime-types-file');
 /**
  * URL for the mime.types file in the Apache HTTPD project source.
  */
-var URL = 'https://svn.apache.org/repos/asf/httpd/httpd/trunk/docs/conf/mime.types'
-var OUT = 'src/apache-types.json'
+var URL = 'https://salsa.debian.org/debian/mime-support/-/raw/master/mime.types?inline=false'
+var OUT = 'src/mime-support-types.json'
 
 getMimeTypes(URL, OUT, function onResponse (err) {
   console.error(err);

--- a/scripts/fetch-mime-types-file.js
+++ b/scripts/fetch-mime-types-file.js
@@ -1,0 +1,95 @@
+'use strict'
+
+/**
+ * Convert these text files to JSON for browser usage.
+ */
+
+var getBody = require('raw-body')
+var https = require('https')
+var writedb = require('./lib/write-db')
+
+/**
+ * Mime types and associated extensions are stored in the form:
+ *
+ *   <type> <ext> <ext> <ext>
+ *
+ * And some are commented out with a leading `#` because they have no associated extensions.
+ * This regexp checks whether a single line matches this format, ignoring lines that are just comments.
+ * We could also just remove all lines that start with `#` if we want to make the JSON files smaller
+ * and ignore all mime types without associated extensions.
+ */
+var TYPE_LINE_REGEXP = /^(?:# )?([\w-]+\/[\w+.-]+)((?:\s+[\w-]+)*)$/gm
+
+function getMimeTypes(URL, OUT, callback) {
+  get(URL, function onResponse (err, body) {
+    if (err) callback(err)
+
+    var json = {}
+    var match = null
+
+    TYPE_LINE_REGEXP.index = 0
+
+    while ((match = TYPE_LINE_REGEXP.exec(body))) {
+      var mime = match[1]
+
+      if (mime.substr(-8) === '/example') {
+        continue
+      }
+
+      // parse the extensions
+      var extensions = (match[2] || '')
+        .split(/\s+/)
+        .filter(Boolean)
+      var data = json[mime] || (json[mime] = {})
+
+      // append the extensions
+      appendExtensions(data, extensions)
+    }
+
+    writedb(OUT, json)
+  })
+}
+
+/**
+ * Append an extension to an object.
+ */
+function appendExtension (obj, extension) {
+  if (!obj.extensions) {
+    obj.extensions = []
+  }
+
+  if (obj.extensions.indexOf(extension) === -1) {
+    obj.extensions.push(extension)
+  }
+}
+
+/**
+ * Append extensions to an object.
+ */
+function appendExtensions (obj, extensions) {
+  if (extensions.length === 0) {
+    return
+  }
+
+  for (var i = 0; i < extensions.length; i++) {
+    var extension = extensions[i]
+
+    // add extension to the type entry
+    appendExtension(obj, extension)
+  }
+}
+
+/**
+ * Get HTTPS resource.
+ */
+function get (url, callback) {
+  https.get(url, function onResponse (res) {
+    if (res.statusCode !== 200) {
+      callback(new Error('got status code ' + res.statusCode + ' from ' + URL))
+    } else {
+      getBody(res, true, callback)
+    }
+  })
+}
+
+module.exports = getMimeTypes;

--- a/scripts/stats.js
+++ b/scripts/stats.js
@@ -1,0 +1,8 @@
+const db = require('../db.json');
+const sources = ['iana', 'apache', 'nginx', 'mime-support', 'custom'];
+console.log('total', Object.values(db).length);
+sources.forEach(src => {
+  console.log(src, Object.values(db).filter(i => i.source === src).length);
+});
+console.log(undefined, Object.values(db).filter(i => i === undefined).length);
+console.log('other', Object.values(db).filter(i => !sources.includes(i.source)).length);

--- a/src/mime-support-types.json
+++ b/src/mime-support-types.json
@@ -1,0 +1,1635 @@
+{
+  "application/activemessage": {},
+  "application/andrew-inset": {
+    "extensions": ["ez"]
+  },
+  "application/annodex": {
+    "extensions": ["anx"]
+  },
+  "application/applefile": {},
+  "application/atom+xml": {
+    "extensions": ["atom"]
+  },
+  "application/atomcat+xml": {
+    "extensions": ["atomcat"]
+  },
+  "application/atomicmail": {},
+  "application/atomserv+xml": {
+    "extensions": ["atomsrv"]
+  },
+  "application/batch-SMTP": {},
+  "application/bbolin": {
+    "extensions": ["lin"]
+  },
+  "application/beep+xml": {},
+  "application/cals-1840": {},
+  "application/commonground": {},
+  "application/cu-seeme": {
+    "extensions": ["cu"]
+  },
+  "application/cybercash": {},
+  "application/davmount+xml": {
+    "extensions": ["davmount"]
+  },
+  "application/dca-rft": {},
+  "application/dec-dx": {},
+  "application/dicom": {
+    "extensions": ["dcm"]
+  },
+  "application/docbook+xml": {},
+  "application/dsptype": {
+    "extensions": ["tsp"]
+  },
+  "application/dvcs": {},
+  "application/ecmascript": {
+    "extensions": ["es"]
+  },
+  "application/edi-consent": {},
+  "application/edi-x12": {},
+  "application/edifact": {},
+  "application/epub+zip": {
+    "extensions": ["epub"]
+  },
+  "application/eshop": {},
+  "application/font-sfnt": {
+    "extensions": ["otf","ttf"]
+  },
+  "application/font-tdpfr": {
+    "extensions": ["pfr"]
+  },
+  "application/font-woff": {
+    "extensions": ["woff"]
+  },
+  "application/futuresplash": {
+    "extensions": ["spl"]
+  },
+  "application/ghostview": {},
+  "application/gzip": {
+    "extensions": ["gz"]
+  },
+  "application/hta": {
+    "extensions": ["hta"]
+  },
+  "application/http": {},
+  "application/hyperstudio": {},
+  "application/iges": {},
+  "application/index": {},
+  "application/index.cmd": {},
+  "application/index.obj": {},
+  "application/index.response": {},
+  "application/index.vnd": {},
+  "application/iotp": {},
+  "application/ipp": {},
+  "application/isup": {},
+  "application/java-archive": {
+    "extensions": ["jar"]
+  },
+  "application/java-serialized-object": {
+    "extensions": ["ser"]
+  },
+  "application/java-vm": {
+    "extensions": ["class"]
+  },
+  "application/javascript": {
+    "extensions": ["js","mjs"]
+  },
+  "application/json": {
+    "extensions": ["json"]
+  },
+  "application/ld+json": {
+    "extensions": ["jsonld"]
+  },
+  "application/m3g": {
+    "extensions": ["m3g"]
+  },
+  "application/mac-binhex40": {
+    "extensions": ["hqx"]
+  },
+  "application/mac-compactpro": {
+    "extensions": ["cpt"]
+  },
+  "application/macwriteii": {},
+  "application/marc": {},
+  "application/mathematica": {
+    "extensions": ["nb","nbp"]
+  },
+  "application/mbox": {
+    "extensions": ["mbox"]
+  },
+  "application/ms-tnef": {},
+  "application/msaccess": {
+    "extensions": ["mdb"]
+  },
+  "application/msword": {
+    "extensions": ["doc","dot"]
+  },
+  "application/mxf": {
+    "extensions": ["mxf"]
+  },
+  "application/news-message-id": {},
+  "application/news-transmission": {},
+  "application/ocsp-request": {},
+  "application/ocsp-response": {},
+  "application/octet-stream": {
+    "extensions": ["bin","deploy","msu","msp"]
+  },
+  "application/oda": {
+    "extensions": ["oda"]
+  },
+  "application/oebps-package+xml": {
+    "extensions": ["opf"]
+  },
+  "application/ogg": {
+    "extensions": ["ogx"]
+  },
+  "application/onenote": {
+    "extensions": ["one","onetoc2","onetmp","onepkg"]
+  },
+  "application/parityfec": {},
+  "application/pdf": {
+    "extensions": ["pdf"]
+  },
+  "application/pgp-encrypted": {
+    "extensions": ["pgp"]
+  },
+  "application/pgp-keys": {
+    "extensions": ["key"]
+  },
+  "application/pgp-signature": {
+    "extensions": ["sig"]
+  },
+  "application/pics-rules": {
+    "extensions": ["prf"]
+  },
+  "application/pkcs10": {},
+  "application/pkcs7-mime": {},
+  "application/pkcs7-signature": {},
+  "application/pkix-cert": {},
+  "application/pkix-crl": {},
+  "application/pkixcmp": {},
+  "application/postscript": {
+    "extensions": ["ps","ai","eps","epsi","epsf","eps2","eps3"]
+  },
+  "application/prs.alvestrand.titrax-sheet": {},
+  "application/prs.cww": {},
+  "application/prs.nprend": {},
+  "application/qsig": {},
+  "application/rar": {
+    "extensions": ["rar"]
+  },
+  "application/rdf+xml": {
+    "extensions": ["rdf"]
+  },
+  "application/remote-printing": {},
+  "application/riscos": {},
+  "application/rtf": {
+    "extensions": ["rtf"]
+  },
+  "application/sdp": {},
+  "application/set-payment": {},
+  "application/set-payment-initiation": {},
+  "application/set-registration": {},
+  "application/set-registration-initiation": {},
+  "application/sgml": {},
+  "application/sgml-open-catalog": {},
+  "application/sieve": {},
+  "application/sla": {
+    "extensions": ["stl"]
+  },
+  "application/slate": {},
+  "application/smil+xml": {
+    "extensions": ["smi","smil"]
+  },
+  "application/timestamp-query": {},
+  "application/timestamp-reply": {},
+  "application/vemmi": {},
+  "application/vnd.3M.Post-it-Notes": {},
+  "application/vnd.accpac.simply.aso": {},
+  "application/vnd.accpac.simply.imp": {},
+  "application/vnd.acucobol": {},
+  "application/vnd.aether.imp": {},
+  "application/vnd.android.package-archive": {
+    "extensions": ["apk"]
+  },
+  "application/vnd.anser-web-certificate-issue-initiation": {},
+  "application/vnd.anser-web-funds-transfer-initiation": {},
+  "application/vnd.audiograph": {},
+  "application/vnd.bmi": {},
+  "application/vnd.businessobjects": {},
+  "application/vnd.canon-cpdl": {},
+  "application/vnd.canon-lips": {},
+  "application/vnd.cinderella": {
+    "extensions": ["cdy"]
+  },
+  "application/vnd.claymore": {},
+  "application/vnd.commerce-battelle": {},
+  "application/vnd.commonspace": {},
+  "application/vnd.comsocaller": {},
+  "application/vnd.contact.cmsg": {},
+  "application/vnd.cosmocaller": {},
+  "application/vnd.ctc-posml": {},
+  "application/vnd.cups-postscript": {},
+  "application/vnd.cups-raster": {},
+  "application/vnd.cups-raw": {},
+  "application/vnd.cybank": {},
+  "application/vnd.debian.binary-package": {
+    "extensions": ["deb","ddeb","udeb"]
+  },
+  "application/vnd.dna": {},
+  "application/vnd.dpgraph": {},
+  "application/vnd.dxr": {},
+  "application/vnd.ecdis-update": {},
+  "application/vnd.ecowin.chart": {},
+  "application/vnd.ecowin.filerequest": {},
+  "application/vnd.ecowin.fileupdate": {},
+  "application/vnd.ecowin.series": {},
+  "application/vnd.ecowin.seriesrequest": {},
+  "application/vnd.ecowin.seriesupdate": {},
+  "application/vnd.enliven": {},
+  "application/vnd.epson.esf": {},
+  "application/vnd.epson.msf": {},
+  "application/vnd.epson.quickanime": {},
+  "application/vnd.epson.salt": {},
+  "application/vnd.epson.ssf": {},
+  "application/vnd.ericsson.quickcall": {},
+  "application/vnd.eudora.data": {},
+  "application/vnd.fdf": {},
+  "application/vnd.ffsns": {},
+  "application/vnd.flographit": {},
+  "application/vnd.font-fontforge-sfd": {
+    "extensions": ["sfd"]
+  },
+  "application/vnd.framemaker": {},
+  "application/vnd.fsc.weblaunch": {},
+  "application/vnd.fujitsu.oasys": {},
+  "application/vnd.fujitsu.oasys2": {},
+  "application/vnd.fujitsu.oasys3": {},
+  "application/vnd.fujitsu.oasysgp": {},
+  "application/vnd.fujitsu.oasysprs": {},
+  "application/vnd.fujixerox.ddd": {},
+  "application/vnd.fujixerox.docuworks": {},
+  "application/vnd.fujixerox.docuworks.binder": {},
+  "application/vnd.fut-misnet": {},
+  "application/vnd.google-earth.kml+xml": {
+    "extensions": ["kml"]
+  },
+  "application/vnd.google-earth.kmz": {
+    "extensions": ["kmz"]
+  },
+  "application/vnd.grafeq": {},
+  "application/vnd.groove-account": {},
+  "application/vnd.groove-identity-message": {},
+  "application/vnd.groove-injector": {},
+  "application/vnd.groove-tool-message": {},
+  "application/vnd.groove-tool-template": {},
+  "application/vnd.groove-vcard": {},
+  "application/vnd.hhe.lesson-player": {},
+  "application/vnd.hp-HPGL": {},
+  "application/vnd.hp-PCL": {},
+  "application/vnd.hp-PCLXL": {},
+  "application/vnd.hp-hpid": {},
+  "application/vnd.hp-hps": {},
+  "application/vnd.httphone": {},
+  "application/vnd.hzn-3d-crossword": {},
+  "application/vnd.ibm.MiniPay": {},
+  "application/vnd.ibm.afplinedata": {},
+  "application/vnd.ibm.modcap": {},
+  "application/vnd.informix-visionary": {},
+  "application/vnd.intercon.formnet": {},
+  "application/vnd.intertrust.digibox": {},
+  "application/vnd.intertrust.nncp": {},
+  "application/vnd.intu.qbo": {},
+  "application/vnd.intu.qfx": {},
+  "application/vnd.irepository.package+xml": {},
+  "application/vnd.is-xpr": {},
+  "application/vnd.japannet-directory-service": {},
+  "application/vnd.japannet-jpnstore-wakeup": {},
+  "application/vnd.japannet-payment-wakeup": {},
+  "application/vnd.japannet-registration": {},
+  "application/vnd.japannet-registration-wakeup": {},
+  "application/vnd.japannet-setstore-wakeup": {},
+  "application/vnd.japannet-verification": {},
+  "application/vnd.japannet-verification-wakeup": {},
+  "application/vnd.koan": {},
+  "application/vnd.lotus-1-2-3": {},
+  "application/vnd.lotus-approach": {},
+  "application/vnd.lotus-freelance": {},
+  "application/vnd.lotus-notes": {},
+  "application/vnd.lotus-organizer": {},
+  "application/vnd.lotus-screencam": {},
+  "application/vnd.lotus-wordpro": {},
+  "application/vnd.mcd": {},
+  "application/vnd.mediastation.cdkey": {},
+  "application/vnd.meridian-slingshot": {},
+  "application/vnd.mif": {},
+  "application/vnd.minisoft-hp3000-save": {},
+  "application/vnd.mitsubishi.misty-guard.trustweb": {},
+  "application/vnd.mobius.daf": {},
+  "application/vnd.mobius.dis": {},
+  "application/vnd.mobius.msl": {},
+  "application/vnd.mobius.plc": {},
+  "application/vnd.mobius.txf": {},
+  "application/vnd.motorola.flexsuite": {},
+  "application/vnd.motorola.flexsuite.adsi": {},
+  "application/vnd.motorola.flexsuite.fis": {},
+  "application/vnd.motorola.flexsuite.gotap": {},
+  "application/vnd.motorola.flexsuite.kmr": {},
+  "application/vnd.motorola.flexsuite.ttc": {},
+  "application/vnd.motorola.flexsuite.wem": {},
+  "application/vnd.mozilla.xul+xml": {
+    "extensions": ["xul"]
+  },
+  "application/vnd.ms-artgalry": {},
+  "application/vnd.ms-asf": {},
+  "application/vnd.ms-excel": {
+    "extensions": ["xls","xlb","xlt"]
+  },
+  "application/vnd.ms-excel.addin.macroEnabled.12": {
+    "extensions": ["xlam"]
+  },
+  "application/vnd.ms-excel.sheet.binary.macroEnabled.12": {
+    "extensions": ["xlsb"]
+  },
+  "application/vnd.ms-excel.sheet.macroEnabled.12": {
+    "extensions": ["xlsm"]
+  },
+  "application/vnd.ms-excel.template.macroEnabled.12": {
+    "extensions": ["xltm"]
+  },
+  "application/vnd.ms-fontobject": {
+    "extensions": ["eot"]
+  },
+  "application/vnd.ms-lrm": {},
+  "application/vnd.ms-officetheme": {
+    "extensions": ["thmx"]
+  },
+  "application/vnd.ms-pki.seccat": {
+    "extensions": ["cat"]
+  },
+  "application/vnd.ms-powerpoint": {
+    "extensions": ["ppt","pps"]
+  },
+  "application/vnd.ms-powerpoint.addin.macroEnabled.12": {
+    "extensions": ["ppam"]
+  },
+  "application/vnd.ms-powerpoint.presentation.macroEnabled.12": {
+    "extensions": ["pptm"]
+  },
+  "application/vnd.ms-powerpoint.slide.macroEnabled.12": {
+    "extensions": ["sldm"]
+  },
+  "application/vnd.ms-powerpoint.slideshow.macroEnabled.12": {
+    "extensions": ["ppsm"]
+  },
+  "application/vnd.ms-powerpoint.template.macroEnabled.12": {
+    "extensions": ["potm"]
+  },
+  "application/vnd.ms-project": {},
+  "application/vnd.ms-tnef": {},
+  "application/vnd.ms-word.document.macroEnabled.12": {
+    "extensions": ["docm"]
+  },
+  "application/vnd.ms-word.template.macroEnabled.12": {
+    "extensions": ["dotm"]
+  },
+  "application/vnd.ms-works": {},
+  "application/vnd.mseq": {},
+  "application/vnd.msign": {},
+  "application/vnd.music-niff": {},
+  "application/vnd.musician": {},
+  "application/vnd.netfpx": {},
+  "application/vnd.noblenet-directory": {},
+  "application/vnd.noblenet-sealer": {},
+  "application/vnd.noblenet-web": {},
+  "application/vnd.novadigm.EDM": {},
+  "application/vnd.novadigm.EDX": {},
+  "application/vnd.novadigm.EXT": {},
+  "application/vnd.oasis.opendocument.chart": {
+    "extensions": ["odc"]
+  },
+  "application/vnd.oasis.opendocument.database": {
+    "extensions": ["odb"]
+  },
+  "application/vnd.oasis.opendocument.formula": {
+    "extensions": ["odf"]
+  },
+  "application/vnd.oasis.opendocument.graphics": {
+    "extensions": ["odg"]
+  },
+  "application/vnd.oasis.opendocument.graphics-template": {
+    "extensions": ["otg"]
+  },
+  "application/vnd.oasis.opendocument.image": {
+    "extensions": ["odi"]
+  },
+  "application/vnd.oasis.opendocument.presentation": {
+    "extensions": ["odp"]
+  },
+  "application/vnd.oasis.opendocument.presentation-template": {
+    "extensions": ["otp"]
+  },
+  "application/vnd.oasis.opendocument.spreadsheet": {
+    "extensions": ["ods"]
+  },
+  "application/vnd.oasis.opendocument.spreadsheet-template": {
+    "extensions": ["ots"]
+  },
+  "application/vnd.oasis.opendocument.text": {
+    "extensions": ["odt"]
+  },
+  "application/vnd.oasis.opendocument.text-master": {
+    "extensions": ["odm"]
+  },
+  "application/vnd.oasis.opendocument.text-template": {
+    "extensions": ["ott"]
+  },
+  "application/vnd.oasis.opendocument.text-web": {
+    "extensions": ["oth"]
+  },
+  "application/vnd.openxmlformats-officedocument.presentationml.presentation": {
+    "extensions": ["pptx"]
+  },
+  "application/vnd.openxmlformats-officedocument.presentationml.slide": {
+    "extensions": ["sldx"]
+  },
+  "application/vnd.openxmlformats-officedocument.presentationml.slideshow": {
+    "extensions": ["ppsx"]
+  },
+  "application/vnd.openxmlformats-officedocument.presentationml.template": {
+    "extensions": ["potx"]
+  },
+  "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet": {
+    "extensions": ["xlsx"]
+  },
+  "application/vnd.openxmlformats-officedocument.spreadsheetml.template": {
+    "extensions": ["xltx"]
+  },
+  "application/vnd.openxmlformats-officedocument.wordprocessingml.document": {
+    "extensions": ["docx"]
+  },
+  "application/vnd.openxmlformats-officedocument.wordprocessingml.template": {
+    "extensions": ["dotx"]
+  },
+  "application/vnd.osa.netdeploy": {},
+  "application/vnd.palm": {},
+  "application/vnd.pg.format": {},
+  "application/vnd.pg.osasli": {},
+  "application/vnd.powerbuilder6": {},
+  "application/vnd.powerbuilder6-s": {},
+  "application/vnd.powerbuilder7": {},
+  "application/vnd.powerbuilder7-s": {},
+  "application/vnd.powerbuilder75": {},
+  "application/vnd.powerbuilder75-s": {},
+  "application/vnd.previewsystems.box": {},
+  "application/vnd.publishare-delta-tree": {},
+  "application/vnd.pvi.ptid1": {},
+  "application/vnd.pwg-xhtml-print+xml": {},
+  "application/vnd.rapid": {},
+  "application/vnd.rim.cod": {
+    "extensions": ["cod"]
+  },
+  "application/vnd.s3sms": {},
+  "application/vnd.seemail": {},
+  "application/vnd.shana.informed.formdata": {},
+  "application/vnd.shana.informed.formtemplate": {},
+  "application/vnd.shana.informed.interchange": {},
+  "application/vnd.shana.informed.package": {},
+  "application/vnd.smaf": {
+    "extensions": ["mmf"]
+  },
+  "application/vnd.sss-cod": {},
+  "application/vnd.sss-dtf": {},
+  "application/vnd.sss-ntf": {},
+  "application/vnd.stardivision.calc": {
+    "extensions": ["sdc"]
+  },
+  "application/vnd.stardivision.chart": {
+    "extensions": ["sds"]
+  },
+  "application/vnd.stardivision.draw": {
+    "extensions": ["sda"]
+  },
+  "application/vnd.stardivision.impress": {
+    "extensions": ["sdd"]
+  },
+  "application/vnd.stardivision.math": {
+    "extensions": ["sdf"]
+  },
+  "application/vnd.stardivision.writer": {
+    "extensions": ["sdw"]
+  },
+  "application/vnd.stardivision.writer-global": {
+    "extensions": ["sgl"]
+  },
+  "application/vnd.street-stream": {},
+  "application/vnd.sun.xml.calc": {
+    "extensions": ["sxc"]
+  },
+  "application/vnd.sun.xml.calc.template": {
+    "extensions": ["stc"]
+  },
+  "application/vnd.sun.xml.draw": {
+    "extensions": ["sxd"]
+  },
+  "application/vnd.sun.xml.draw.template": {
+    "extensions": ["std"]
+  },
+  "application/vnd.sun.xml.impress": {
+    "extensions": ["sxi"]
+  },
+  "application/vnd.sun.xml.impress.template": {
+    "extensions": ["sti"]
+  },
+  "application/vnd.sun.xml.math": {
+    "extensions": ["sxm"]
+  },
+  "application/vnd.sun.xml.writer": {
+    "extensions": ["sxw"]
+  },
+  "application/vnd.sun.xml.writer.global": {
+    "extensions": ["sxg"]
+  },
+  "application/vnd.sun.xml.writer.template": {
+    "extensions": ["stw"]
+  },
+  "application/vnd.svd": {},
+  "application/vnd.swiftview-ics": {},
+  "application/vnd.symbian.install": {
+    "extensions": ["sis"]
+  },
+  "application/vnd.tcpdump.pcap": {
+    "extensions": ["cap","pcap"]
+  },
+  "application/vnd.triscape.mxs": {},
+  "application/vnd.trueapp": {},
+  "application/vnd.truedoc": {},
+  "application/vnd.tve-trigger": {},
+  "application/vnd.ufdl": {},
+  "application/vnd.uplanet.alert": {},
+  "application/vnd.uplanet.alert-wbxml": {},
+  "application/vnd.uplanet.bearer-choice": {},
+  "application/vnd.uplanet.bearer-choice-wbxml": {},
+  "application/vnd.uplanet.cacheop": {},
+  "application/vnd.uplanet.cacheop-wbxml": {},
+  "application/vnd.uplanet.channel": {},
+  "application/vnd.uplanet.channel-wbxml": {},
+  "application/vnd.uplanet.list": {},
+  "application/vnd.uplanet.list-wbxml": {},
+  "application/vnd.uplanet.listcmd": {},
+  "application/vnd.uplanet.listcmd-wbxml": {},
+  "application/vnd.uplanet.signal": {},
+  "application/vnd.vcx": {},
+  "application/vnd.vectorworks": {},
+  "application/vnd.vidsoft.vidconference": {},
+  "application/vnd.visio": {
+    "extensions": ["vsd","vst","vsw","vss"]
+  },
+  "application/vnd.vividence.scriptfile": {},
+  "application/vnd.wap.sic": {},
+  "application/vnd.wap.slc": {},
+  "application/vnd.wap.wbxml": {
+    "extensions": ["wbxml"]
+  },
+  "application/vnd.wap.wmlc": {
+    "extensions": ["wmlc"]
+  },
+  "application/vnd.wap.wmlscriptc": {
+    "extensions": ["wmlsc"]
+  },
+  "application/vnd.webturbo": {},
+  "application/vnd.wordperfect": {
+    "extensions": ["wpd"]
+  },
+  "application/vnd.wordperfect5.1": {
+    "extensions": ["wp5"]
+  },
+  "application/vnd.wrq-hp3000-labelled": {},
+  "application/vnd.wt.stf": {},
+  "application/vnd.xara": {},
+  "application/vnd.xfdl": {},
+  "application/vnd.yellowriver-custom-menu": {},
+  "application/wasm": {
+    "extensions": ["wasm"]
+  },
+  "application/whoispp-query": {},
+  "application/whoispp-response": {},
+  "application/wita": {},
+  "application/x-123": {
+    "extensions": ["wk"]
+  },
+  "application/x-7z-compressed": {
+    "extensions": ["7z"]
+  },
+  "application/x-abiword": {
+    "extensions": ["abw"]
+  },
+  "application/x-apple-diskimage": {
+    "extensions": ["dmg"]
+  },
+  "application/x-bcpio": {
+    "extensions": ["bcpio"]
+  },
+  "application/x-bittorrent": {
+    "extensions": ["torrent"]
+  },
+  "application/x-cab": {
+    "extensions": ["cab"]
+  },
+  "application/x-cbr": {
+    "extensions": ["cbr"]
+  },
+  "application/x-cbz": {
+    "extensions": ["cbz"]
+  },
+  "application/x-cdf": {
+    "extensions": ["cdf","cda"]
+  },
+  "application/x-cdlink": {
+    "extensions": ["vcd"]
+  },
+  "application/x-chess-pgn": {
+    "extensions": ["pgn"]
+  },
+  "application/x-comsol": {
+    "extensions": ["mph"]
+  },
+  "application/x-core": {},
+  "application/x-cpio": {
+    "extensions": ["cpio"]
+  },
+  "application/x-csh": {
+    "extensions": ["csh"]
+  },
+  "application/x-debian-package": {
+    "extensions": ["deb","udeb"]
+  },
+  "application/x-director": {
+    "extensions": ["dcr","dir","dxr"]
+  },
+  "application/x-dms": {
+    "extensions": ["dms"]
+  },
+  "application/x-doom": {
+    "extensions": ["wad"]
+  },
+  "application/x-dvi": {
+    "extensions": ["dvi"]
+  },
+  "application/x-executable": {},
+  "application/x-font": {
+    "extensions": ["pfa","pfb","gsf"]
+  },
+  "application/x-freemind": {
+    "extensions": ["mm"]
+  },
+  "application/x-futuresplash": {
+    "extensions": ["spl"]
+  },
+  "application/x-ganttproject": {
+    "extensions": ["gan"]
+  },
+  "application/x-gnumeric": {
+    "extensions": ["gnumeric"]
+  },
+  "application/x-go-sgf": {
+    "extensions": ["sgf"]
+  },
+  "application/x-graphing-calculator": {
+    "extensions": ["gcf"]
+  },
+  "application/x-gtar": {
+    "extensions": ["gtar"]
+  },
+  "application/x-gtar-compressed": {
+    "extensions": ["tgz","taz"]
+  },
+  "application/x-hdf": {
+    "extensions": ["hdf"]
+  },
+  "application/x-hwp": {
+    "extensions": ["hwp"]
+  },
+  "application/x-ica": {
+    "extensions": ["ica"]
+  },
+  "application/x-info": {
+    "extensions": ["info"]
+  },
+  "application/x-internet-signup": {
+    "extensions": ["ins","isp"]
+  },
+  "application/x-iphone": {
+    "extensions": ["iii"]
+  },
+  "application/x-iso9660-image": {
+    "extensions": ["iso"]
+  },
+  "application/x-jam": {
+    "extensions": ["jam"]
+  },
+  "application/x-java-applet": {},
+  "application/x-java-bean": {},
+  "application/x-java-jnlp-file": {
+    "extensions": ["jnlp"]
+  },
+  "application/x-jmol": {
+    "extensions": ["jmz"]
+  },
+  "application/x-kchart": {
+    "extensions": ["chrt"]
+  },
+  "application/x-kdelnk": {},
+  "application/x-killustrator": {
+    "extensions": ["kil"]
+  },
+  "application/x-koan": {
+    "extensions": ["skp","skd","skt","skm"]
+  },
+  "application/x-kpresenter": {
+    "extensions": ["kpr","kpt"]
+  },
+  "application/x-kspread": {
+    "extensions": ["ksp"]
+  },
+  "application/x-kword": {
+    "extensions": ["kwd","kwt"]
+  },
+  "application/x-latex": {
+    "extensions": ["latex"]
+  },
+  "application/x-lha": {
+    "extensions": ["lha"]
+  },
+  "application/x-lyx": {
+    "extensions": ["lyx"]
+  },
+  "application/x-lzh": {
+    "extensions": ["lzh"]
+  },
+  "application/x-lzx": {
+    "extensions": ["lzx"]
+  },
+  "application/x-maker": {
+    "extensions": ["frm","maker","frame","fm","fb","book","fbdoc"]
+  },
+  "application/x-mif": {
+    "extensions": ["mif"]
+  },
+  "application/x-mpegURL": {
+    "extensions": ["m3u8"]
+  },
+  "application/x-ms-application": {
+    "extensions": ["application"]
+  },
+  "application/x-ms-manifest": {
+    "extensions": ["manifest"]
+  },
+  "application/x-ms-wmd": {
+    "extensions": ["wmd"]
+  },
+  "application/x-ms-wmz": {
+    "extensions": ["wmz"]
+  },
+  "application/x-msdos-program": {
+    "extensions": ["com","exe","bat","dll"]
+  },
+  "application/x-msi": {
+    "extensions": ["msi"]
+  },
+  "application/x-netcdf": {
+    "extensions": ["nc"]
+  },
+  "application/x-ns-proxy-autoconfig": {
+    "extensions": ["pac"]
+  },
+  "application/x-nwc": {
+    "extensions": ["nwc"]
+  },
+  "application/x-object": {
+    "extensions": ["o"]
+  },
+  "application/x-oz-application": {
+    "extensions": ["oza"]
+  },
+  "application/x-pkcs7-certreqresp": {
+    "extensions": ["p7r"]
+  },
+  "application/x-pkcs7-crl": {
+    "extensions": ["crl"]
+  },
+  "application/x-python-code": {
+    "extensions": ["pyc","pyo"]
+  },
+  "application/x-qgis": {
+    "extensions": ["qgs","shp","shx"]
+  },
+  "application/x-quicktimeplayer": {
+    "extensions": ["qtl"]
+  },
+  "application/x-rdp": {
+    "extensions": ["rdp"]
+  },
+  "application/x-redhat-package-manager": {
+    "extensions": ["rpm"]
+  },
+  "application/x-rss+xml": {
+    "extensions": ["rss"]
+  },
+  "application/x-ruby": {
+    "extensions": ["rb"]
+  },
+  "application/x-rx": {},
+  "application/x-scilab": {
+    "extensions": ["sci","sce"]
+  },
+  "application/x-scilab-xcos": {
+    "extensions": ["xcos"]
+  },
+  "application/x-sh": {
+    "extensions": ["sh"]
+  },
+  "application/x-shar": {
+    "extensions": ["shar"]
+  },
+  "application/x-shellscript": {},
+  "application/x-shockwave-flash": {
+    "extensions": ["swf","swfl"]
+  },
+  "application/x-silverlight": {
+    "extensions": ["scr"]
+  },
+  "application/x-sql": {
+    "extensions": ["sql"]
+  },
+  "application/x-stuffit": {
+    "extensions": ["sit","sitx"]
+  },
+  "application/x-sv4cpio": {
+    "extensions": ["sv4cpio"]
+  },
+  "application/x-sv4crc": {
+    "extensions": ["sv4crc"]
+  },
+  "application/x-tar": {
+    "extensions": ["tar"]
+  },
+  "application/x-tcl": {
+    "extensions": ["tcl"]
+  },
+  "application/x-tex-gf": {
+    "extensions": ["gf"]
+  },
+  "application/x-tex-pk": {
+    "extensions": ["pk"]
+  },
+  "application/x-texinfo": {
+    "extensions": ["texinfo","texi"]
+  },
+  "application/x-troff": {
+    "extensions": ["t","tr","roff"]
+  },
+  "application/x-troff-man": {
+    "extensions": ["man"]
+  },
+  "application/x-troff-me": {
+    "extensions": ["me"]
+  },
+  "application/x-troff-ms": {
+    "extensions": ["ms"]
+  },
+  "application/x-ustar": {
+    "extensions": ["ustar"]
+  },
+  "application/x-videolan": {},
+  "application/x-wais-source": {
+    "extensions": ["src"]
+  },
+  "application/x-wingz": {
+    "extensions": ["wz"]
+  },
+  "application/x-x509-ca-cert": {
+    "extensions": ["crt"]
+  },
+  "application/x-xcf": {
+    "extensions": ["xcf"]
+  },
+  "application/x-xfig": {
+    "extensions": ["fig"]
+  },
+  "application/x-xpinstall": {
+    "extensions": ["xpi"]
+  },
+  "application/x-xz": {
+    "extensions": ["xz"]
+  },
+  "application/x400-bp": {},
+  "application/xhtml+xml": {
+    "extensions": ["xhtml","xht"]
+  },
+  "application/xml": {
+    "extensions": ["xml","xsd"]
+  },
+  "application/xml-dtd": {},
+  "application/xml-external-parsed-entity": {},
+  "application/xslt+xml": {
+    "extensions": ["xsl","xslt"]
+  },
+  "application/xspf+xml": {
+    "extensions": ["xspf"]
+  },
+  "application/zip": {
+    "extensions": ["zip"]
+  },
+  "application/zlib": {},
+  "audio/32kadpcm": {},
+  "audio/3gpp": {},
+  "audio/amr": {
+    "extensions": ["amr"]
+  },
+  "audio/amr-wb": {
+    "extensions": ["awb"]
+  },
+  "audio/annodex": {
+    "extensions": ["axa"]
+  },
+  "audio/basic": {
+    "extensions": ["au","snd"]
+  },
+  "audio/csound": {
+    "extensions": ["csd","orc","sco"]
+  },
+  "audio/flac": {
+    "extensions": ["flac"]
+  },
+  "audio/g.722.1": {},
+  "audio/l16": {},
+  "audio/midi": {
+    "extensions": ["mid","midi","kar"]
+  },
+  "audio/mp4a-latm": {},
+  "audio/mpa-robust": {},
+  "audio/mpeg": {
+    "extensions": ["mpga","mpega","mp2","mp3","m4a"]
+  },
+  "audio/mpegurl": {
+    "extensions": ["m3u"]
+  },
+  "audio/ogg": {
+    "extensions": ["oga","ogg","opus","spx"]
+  },
+  "audio/parityfec": {},
+  "audio/prs.sid": {
+    "extensions": ["sid"]
+  },
+  "audio/telephone-event": {},
+  "audio/tone": {},
+  "audio/vnd.cisco.nse": {},
+  "audio/vnd.cns.anp1": {},
+  "audio/vnd.cns.inf1": {},
+  "audio/vnd.digital-winds": {},
+  "audio/vnd.everad.plj": {},
+  "audio/vnd.lucent.voice": {},
+  "audio/vnd.nortel.vbk": {},
+  "audio/vnd.nuera.ecelp4800": {},
+  "audio/vnd.nuera.ecelp7470": {},
+  "audio/vnd.nuera.ecelp9600": {},
+  "audio/vnd.octel.sbc": {},
+  "audio/vnd.qcelp": {},
+  "audio/vnd.rhetorex.32kadpcm": {},
+  "audio/vnd.vmx.cvsd": {},
+  "audio/x-aiff": {
+    "extensions": ["aif","aiff","aifc"]
+  },
+  "audio/x-gsm": {
+    "extensions": ["gsm"]
+  },
+  "audio/x-mpegurl": {
+    "extensions": ["m3u"]
+  },
+  "audio/x-ms-wax": {
+    "extensions": ["wax"]
+  },
+  "audio/x-ms-wma": {
+    "extensions": ["wma"]
+  },
+  "audio/x-pn-realaudio": {
+    "extensions": ["ra","rm","ram"]
+  },
+  "audio/x-pn-realaudio-plugin": {},
+  "audio/x-realaudio": {
+    "extensions": ["ra"]
+  },
+  "audio/x-scpls": {
+    "extensions": ["pls"]
+  },
+  "audio/x-sd2": {
+    "extensions": ["sd2"]
+  },
+  "audio/x-wav": {
+    "extensions": ["wav"]
+  },
+  "chemical/x-alchemy": {
+    "extensions": ["alc"]
+  },
+  "chemical/x-cache": {
+    "extensions": ["cac","cache"]
+  },
+  "chemical/x-cache-csf": {
+    "extensions": ["csf"]
+  },
+  "chemical/x-cactvs-binary": {
+    "extensions": ["cbin","cascii","ctab"]
+  },
+  "chemical/x-cdx": {
+    "extensions": ["cdx"]
+  },
+  "chemical/x-cerius": {
+    "extensions": ["cer"]
+  },
+  "chemical/x-chem3d": {
+    "extensions": ["c3d"]
+  },
+  "chemical/x-chemdraw": {
+    "extensions": ["chm"]
+  },
+  "chemical/x-cif": {
+    "extensions": ["cif"]
+  },
+  "chemical/x-cmdf": {
+    "extensions": ["cmdf"]
+  },
+  "chemical/x-cml": {
+    "extensions": ["cml"]
+  },
+  "chemical/x-compass": {
+    "extensions": ["cpa"]
+  },
+  "chemical/x-crossfire": {
+    "extensions": ["bsd"]
+  },
+  "chemical/x-csml": {
+    "extensions": ["csml","csm"]
+  },
+  "chemical/x-ctx": {
+    "extensions": ["ctx"]
+  },
+  "chemical/x-cxf": {
+    "extensions": ["cxf","cef"]
+  },
+  "chemical/x-embl-dl-nucleotide": {
+    "extensions": ["emb","embl"]
+  },
+  "chemical/x-galactic-spc": {
+    "extensions": ["spc"]
+  },
+  "chemical/x-gamess-input": {
+    "extensions": ["inp","gam","gamin"]
+  },
+  "chemical/x-gaussian-checkpoint": {
+    "extensions": ["fch","fchk"]
+  },
+  "chemical/x-gaussian-cube": {
+    "extensions": ["cub"]
+  },
+  "chemical/x-gaussian-input": {
+    "extensions": ["gau","gjc","gjf"]
+  },
+  "chemical/x-gaussian-log": {
+    "extensions": ["gal"]
+  },
+  "chemical/x-gcg8-sequence": {
+    "extensions": ["gcg"]
+  },
+  "chemical/x-genbank": {
+    "extensions": ["gen"]
+  },
+  "chemical/x-hin": {
+    "extensions": ["hin"]
+  },
+  "chemical/x-isostar": {
+    "extensions": ["istr","ist"]
+  },
+  "chemical/x-jcamp-dx": {
+    "extensions": ["jdx","dx"]
+  },
+  "chemical/x-kinemage": {
+    "extensions": ["kin"]
+  },
+  "chemical/x-macmolecule": {
+    "extensions": ["mcm"]
+  },
+  "chemical/x-macromodel-input": {
+    "extensions": ["mmd","mmod"]
+  },
+  "chemical/x-mdl-molfile": {
+    "extensions": ["mol"]
+  },
+  "chemical/x-mdl-rdfile": {
+    "extensions": ["rd"]
+  },
+  "chemical/x-mdl-rxnfile": {
+    "extensions": ["rxn"]
+  },
+  "chemical/x-mdl-sdfile": {
+    "extensions": ["sd","sdf"]
+  },
+  "chemical/x-mdl-tgf": {
+    "extensions": ["tgf"]
+  },
+  "chemical/x-mmcif": {
+    "extensions": ["mcif"]
+  },
+  "chemical/x-mol2": {
+    "extensions": ["mol2"]
+  },
+  "chemical/x-molconn-Z": {
+    "extensions": ["b"]
+  },
+  "chemical/x-mopac-graph": {
+    "extensions": ["gpt"]
+  },
+  "chemical/x-mopac-input": {
+    "extensions": ["mop","mopcrt","mpc","zmt"]
+  },
+  "chemical/x-mopac-out": {
+    "extensions": ["moo"]
+  },
+  "chemical/x-mopac-vib": {
+    "extensions": ["mvb"]
+  },
+  "chemical/x-ncbi-asn1": {
+    "extensions": ["asn"]
+  },
+  "chemical/x-ncbi-asn1-ascii": {
+    "extensions": ["prt","ent"]
+  },
+  "chemical/x-ncbi-asn1-binary": {
+    "extensions": ["val","aso"]
+  },
+  "chemical/x-ncbi-asn1-spec": {
+    "extensions": ["asn"]
+  },
+  "chemical/x-pdb": {
+    "extensions": ["pdb","ent"]
+  },
+  "chemical/x-rosdal": {
+    "extensions": ["ros"]
+  },
+  "chemical/x-swissprot": {
+    "extensions": ["sw"]
+  },
+  "chemical/x-vamas-iso14976": {
+    "extensions": ["vms"]
+  },
+  "chemical/x-vmd": {
+    "extensions": ["vmd"]
+  },
+  "chemical/x-xtel": {
+    "extensions": ["xtel"]
+  },
+  "chemical/x-xyz": {
+    "extensions": ["xyz"]
+  },
+  "font/collection": {
+    "extensions": ["ttc"]
+  },
+  "font/otf": {
+    "extensions": ["ttf","otf"]
+  },
+  "font/sfnt": {
+    "extensions": ["ttf","otf"]
+  },
+  "font/ttf": {
+    "extensions": ["ttf","otf"]
+  },
+  "font/woff": {
+    "extensions": ["woff"]
+  },
+  "font/woff2": {
+    "extensions": ["woff2"]
+  },
+  "image/cgm": {},
+  "image/g3fax": {},
+  "image/gif": {
+    "extensions": ["gif"]
+  },
+  "image/ief": {
+    "extensions": ["ief"]
+  },
+  "image/jp2": {
+    "extensions": ["jp2","jpg2"]
+  },
+  "image/jpeg": {
+    "extensions": ["jpeg","jpg","jpe"]
+  },
+  "image/jpm": {
+    "extensions": ["jpm"]
+  },
+  "image/jpx": {
+    "extensions": ["jpx","jpf"]
+  },
+  "image/naplps": {},
+  "image/pcx": {
+    "extensions": ["pcx"]
+  },
+  "image/png": {
+    "extensions": ["png"]
+  },
+  "image/prs.btif": {},
+  "image/prs.pti": {},
+  "image/svg+xml": {
+    "extensions": ["svg","svgz"]
+  },
+  "image/tiff": {
+    "extensions": ["tiff","tif"]
+  },
+  "image/vnd.cns.inf2": {},
+  "image/vnd.djvu": {
+    "extensions": ["djvu","djv"]
+  },
+  "image/vnd.dwg": {},
+  "image/vnd.dxf": {},
+  "image/vnd.fastbidsheet": {},
+  "image/vnd.fpx": {},
+  "image/vnd.fst": {},
+  "image/vnd.fujixerox.edmics-mmr": {},
+  "image/vnd.fujixerox.edmics-rlc": {},
+  "image/vnd.microsoft.icon": {
+    "extensions": ["ico"]
+  },
+  "image/vnd.mix": {},
+  "image/vnd.net-fpx": {},
+  "image/vnd.svf": {},
+  "image/vnd.wap.wbmp": {
+    "extensions": ["wbmp"]
+  },
+  "image/vnd.xiff": {},
+  "image/x-canon-cr2": {
+    "extensions": ["cr2"]
+  },
+  "image/x-canon-crw": {
+    "extensions": ["crw"]
+  },
+  "image/x-cmu-raster": {
+    "extensions": ["ras"]
+  },
+  "image/x-coreldraw": {
+    "extensions": ["cdr"]
+  },
+  "image/x-coreldrawpattern": {
+    "extensions": ["pat"]
+  },
+  "image/x-coreldrawtemplate": {
+    "extensions": ["cdt"]
+  },
+  "image/x-corelphotopaint": {
+    "extensions": ["cpt"]
+  },
+  "image/x-epson-erf": {
+    "extensions": ["erf"]
+  },
+  "image/x-icon": {},
+  "image/x-jg": {
+    "extensions": ["art"]
+  },
+  "image/x-jng": {
+    "extensions": ["jng"]
+  },
+  "image/x-ms-bmp": {
+    "extensions": ["bmp"]
+  },
+  "image/x-nikon-nef": {
+    "extensions": ["nef"]
+  },
+  "image/x-olympus-orf": {
+    "extensions": ["orf"]
+  },
+  "image/x-photoshop": {
+    "extensions": ["psd"]
+  },
+  "image/x-portable-anymap": {
+    "extensions": ["pnm"]
+  },
+  "image/x-portable-bitmap": {
+    "extensions": ["pbm"]
+  },
+  "image/x-portable-graymap": {
+    "extensions": ["pgm"]
+  },
+  "image/x-portable-pixmap": {
+    "extensions": ["ppm"]
+  },
+  "image/x-rgb": {
+    "extensions": ["rgb"]
+  },
+  "image/x-xbitmap": {
+    "extensions": ["xbm"]
+  },
+  "image/x-xpixmap": {
+    "extensions": ["xpm"]
+  },
+  "image/x-xwindowdump": {
+    "extensions": ["xwd"]
+  },
+  "inode/blockdevice": {},
+  "inode/chardevice": {},
+  "inode/directory": {},
+  "inode/directory-locked": {},
+  "inode/fifo": {},
+  "inode/socket": {},
+  "message/delivery-status": {},
+  "message/disposition-notification": {},
+  "message/external-body": {},
+  "message/http": {},
+  "message/news": {},
+  "message/partial": {},
+  "message/rfc822": {
+    "extensions": ["eml"]
+  },
+  "message/s-http": {},
+  "model/iges": {
+    "extensions": ["igs","iges"]
+  },
+  "model/mesh": {
+    "extensions": ["msh","mesh","silo"]
+  },
+  "model/vnd.dwf": {},
+  "model/vnd.flatland.3dml": {},
+  "model/vnd.gdl": {},
+  "model/vnd.gs-gdl": {},
+  "model/vnd.gtw": {},
+  "model/vnd.mts": {},
+  "model/vnd.vtu": {},
+  "model/vrml": {
+    "extensions": ["wrl","vrml"]
+  },
+  "model/x3d+binary": {
+    "extensions": ["x3db"]
+  },
+  "model/x3d+vrml": {
+    "extensions": ["x3dv"]
+  },
+  "model/x3d+xml": {
+    "extensions": ["x3d"]
+  },
+  "multipart/alternative": {},
+  "multipart/appledouble": {},
+  "multipart/byteranges": {},
+  "multipart/digest": {},
+  "multipart/encrypted": {},
+  "multipart/form-data": {},
+  "multipart/header-set": {},
+  "multipart/mixed": {},
+  "multipart/parallel": {},
+  "multipart/related": {},
+  "multipart/report": {},
+  "multipart/signed": {},
+  "multipart/voice-message": {},
+  "text/cache-manifest": {
+    "extensions": ["appcache"]
+  },
+  "text/calendar": {
+    "extensions": ["ics","icz"]
+  },
+  "text/css": {
+    "extensions": ["css"]
+  },
+  "text/csv": {
+    "extensions": ["csv"]
+  },
+  "text/directory": {},
+  "text/english": {},
+  "text/enriched": {},
+  "text/h323": {
+    "extensions": ["323"]
+  },
+  "text/html": {
+    "extensions": ["html","htm","shtml"]
+  },
+  "text/iuls": {
+    "extensions": ["uls"]
+  },
+  "text/markdown": {
+    "extensions": ["md","markdown"]
+  },
+  "text/mathml": {
+    "extensions": ["mml"]
+  },
+  "text/parityfec": {},
+  "text/plain": {
+    "extensions": ["asc","txt","text","pot","brf","srt"]
+  },
+  "text/prs.lines.tag": {},
+  "text/rfc822-headers": {},
+  "text/richtext": {
+    "extensions": ["rtx"]
+  },
+  "text/rtf": {},
+  "text/scriptlet": {
+    "extensions": ["sct","wsc"]
+  },
+  "text/t140": {},
+  "text/tab-separated-values": {
+    "extensions": ["tsv"]
+  },
+  "text/texmacs": {
+    "extensions": ["tm"]
+  },
+  "text/turtle": {
+    "extensions": ["ttl"]
+  },
+  "text/uri-list": {},
+  "text/vcard": {
+    "extensions": ["vcf","vcard"]
+  },
+  "text/vnd.DMClientScript": {},
+  "text/vnd.IPTC.NITF": {},
+  "text/vnd.IPTC.NewsML": {},
+  "text/vnd.abc": {},
+  "text/vnd.curl": {},
+  "text/vnd.debian.copyright": {},
+  "text/vnd.flatland.3dml": {},
+  "text/vnd.fly": {},
+  "text/vnd.fmi.flexstor": {},
+  "text/vnd.in3d.3dml": {},
+  "text/vnd.in3d.spot": {},
+  "text/vnd.latex-z": {},
+  "text/vnd.motorola.reflex": {},
+  "text/vnd.ms-mediapackage": {},
+  "text/vnd.sun.j2me.app-descriptor": {
+    "extensions": ["jad"]
+  },
+  "text/vnd.wap.si": {},
+  "text/vnd.wap.sl": {},
+  "text/vnd.wap.wml": {
+    "extensions": ["wml"]
+  },
+  "text/vnd.wap.wmlscript": {
+    "extensions": ["wmls"]
+  },
+  "text/x-bibtex": {
+    "extensions": ["bib"]
+  },
+  "text/x-boo": {
+    "extensions": ["boo"]
+  },
+  "text/x-chdr": {
+    "extensions": ["h"]
+  },
+  "text/x-component": {
+    "extensions": ["htc"]
+  },
+  "text/x-crontab": {},
+  "text/x-csh": {
+    "extensions": ["csh"]
+  },
+  "text/x-csrc": {
+    "extensions": ["c"]
+  },
+  "text/x-diff": {
+    "extensions": ["diff","patch"]
+  },
+  "text/x-dsrc": {
+    "extensions": ["d"]
+  },
+  "text/x-haskell": {
+    "extensions": ["hs"]
+  },
+  "text/x-java": {
+    "extensions": ["java"]
+  },
+  "text/x-lilypond": {
+    "extensions": ["ly"]
+  },
+  "text/x-literate-haskell": {
+    "extensions": ["lhs"]
+  },
+  "text/x-makefile": {},
+  "text/x-moc": {
+    "extensions": ["moc"]
+  },
+  "text/x-pascal": {
+    "extensions": ["p","pas"]
+  },
+  "text/x-pcs-gcd": {
+    "extensions": ["gcd"]
+  },
+  "text/x-perl": {
+    "extensions": ["pl","pm"]
+  },
+  "text/x-python": {
+    "extensions": ["py"]
+  },
+  "text/x-scala": {
+    "extensions": ["scala"]
+  },
+  "text/x-server-parsed-html": {},
+  "text/x-setext": {
+    "extensions": ["etx"]
+  },
+  "text/x-sfv": {
+    "extensions": ["sfv"]
+  },
+  "text/x-sh": {
+    "extensions": ["sh"]
+  },
+  "text/x-tcl": {
+    "extensions": ["tcl","tk"]
+  },
+  "text/x-tex": {
+    "extensions": ["tex","ltx","sty","cls"]
+  },
+  "text/x-vcalendar": {
+    "extensions": ["vcs"]
+  },
+  "video/3gpp": {
+    "extensions": ["3gp"]
+  },
+  "video/MP2T": {
+    "extensions": ["ts"]
+  },
+  "video/annodex": {
+    "extensions": ["axv"]
+  },
+  "video/dl": {
+    "extensions": ["dl"]
+  },
+  "video/dv": {
+    "extensions": ["dif","dv"]
+  },
+  "video/fli": {
+    "extensions": ["fli"]
+  },
+  "video/gl": {
+    "extensions": ["gl"]
+  },
+  "video/mp4": {
+    "extensions": ["mp4"]
+  },
+  "video/mp4v-es": {},
+  "video/mpeg": {
+    "extensions": ["mpeg","mpg","mpe"]
+  },
+  "video/ogg": {
+    "extensions": ["ogv"]
+  },
+  "video/parityfec": {},
+  "video/pointer": {},
+  "video/quicktime": {
+    "extensions": ["qt","mov"]
+  },
+  "video/vnd.fvt": {},
+  "video/vnd.motorola.video": {},
+  "video/vnd.motorola.videop": {},
+  "video/vnd.mpegurl": {
+    "extensions": ["mxu"]
+  },
+  "video/vnd.mts": {},
+  "video/vnd.nokia.interleaved-multimedia": {},
+  "video/vnd.vivo": {},
+  "video/webm": {
+    "extensions": ["webm"]
+  },
+  "video/x-flv": {
+    "extensions": ["flv"]
+  },
+  "video/x-la-asf": {
+    "extensions": ["lsf","lsx"]
+  },
+  "video/x-matroska": {
+    "extensions": ["mpv","mkv"]
+  },
+  "video/x-mng": {
+    "extensions": ["mng"]
+  },
+  "video/x-ms-asf": {
+    "extensions": ["asf","asx"]
+  },
+  "video/x-ms-wm": {
+    "extensions": ["wm"]
+  },
+  "video/x-ms-wmv": {
+    "extensions": ["wmv"]
+  },
+  "video/x-ms-wmx": {
+    "extensions": ["wmx"]
+  },
+  "video/x-ms-wvx": {
+    "extensions": ["wvx"]
+  },
+  "video/x-msvideo": {
+    "extensions": ["avi"]
+  },
+  "video/x-sgi-movie": {
+    "extensions": ["movie"]
+  },
+  "x-conference/x-cooltalk": {
+    "extensions": ["ice"]
+  },
+  "x-epoc/x-sisx-app": {
+    "extensions": ["sisx"]
+  },
+  "x-world/x-vrml": {
+    "extensions": ["vrm","vrml","wrl"]
+  }
+}


### PR DESCRIPTION
File structure is identical to Apache as the upstream file is a drop in replacement for the Apache mime.types files (actually it's the other way around ..).

In this PR I've added a basic script to print out how many MIME from each source. I've also labelled custom types explicitly to help with tracing source in `db.json`:

**Before:**

    total 2193
    iana 1861
    apache 250
    nginx 13
    mime-support 0
    custom 0
    undefined 0
    other 69

**After:**

    total 2381
    iana 1861
    apache 250
    nginx 13
    mime-support 192
    custom 65
    undefined 0
    other 0

---

 - *Copy right info:* https://salsa.debian.org/debian/mime-support/-/blob/master/debian/copyright
 - *DB Lineage:* A major upstream source of these MIME types is Freedesktop.org [shared-mime-info](https://gitlab.freedesktop.org/xdg/shared-mime-info/-/blob/master/data/freedesktop.org.xml.in). Beyond that it's unclear exactly but you can see the commit history [here](https://salsa.debian.org/debian/mime-support/-/commits/master/mime.types). I feel it is much the same as Apache and Nginx: The maintainers just add entries as they see fit when it's reasonable. Also note, it is this file that is the default mime.types file, and the file that will be used by Apache server (or probably any other kind of HTTP server) running on a Debian based distro, given Apache is installed from pkg manager.