### PR TITLE
fix: add .opus as valid extension for audio/ogg

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,6 +1,7 @@
 unreleased
 ==========
 
+  * Add extension `.opus` to `audio/ogg`
   * Add new upstream MIME types
 
 1.45.0 / 2020-09-22

--- a/db.json
+++ b/db.json
@@ -6441,7 +6441,7 @@
   "audio/ogg": {
     "source": "iana",
     "compressible": false,
-    "extensions": ["oga","ogg","spx"]
+    "extensions": ["oga","ogg","spx","opus"]
   },
   "audio/opus": {
     "source": "iana"

--- a/src/custom-types.json
+++ b/src/custom-types.json
@@ -473,7 +473,11 @@
     "compressible": false
   },
   "audio/ogg": {
-    "compressible": false
+    "compressible": false,
+    "extensions": ["opus"],
+    "sources": [
+      "https://www.iana.org/assignments/media-types/audio/ogg"
+    ]
   },
   "audio/vnd.rn-realaudio": {
     "compressible": false


### PR DESCRIPTION
As per https://www.iana.org/assignments/media-types/audio/ogg .opus
should be considered a valid extension for `audio/ogg` mediatype.

Fixes #193