### PR TITLE
Remove charset from application/json

### DIFF
--- a/src/custom-types.json
+++ b/src/custom-types.json
@@ -71,7 +71,6 @@
     ]
   },
   "application/json": {
-    "charset": "UTF-8",
     "compressible": true,
     "extensions": ["map"]
   },


### PR DESCRIPTION
This was done to fix Azure domain registration with GitHub pages.
It has had multiple issues in multiple repositories and this seems like the only way to fix it.

https://docs.microsoft.com/en-us/answers/questions/13291/publisher-domain-verification-fails-because-verifi.html
https://github.com/MicrosoftDocs/azure-docs/issues/46080
https://github.com/jekyll/jekyll/issues/8006