### PR TITLE
.toml as text/plain

### DIFF
--- a/src/custom-types.json
+++ b/src/custom-types.json
@@ -761,7 +761,7 @@
   },
   "text/plain": {
     "compressible": true,
-    "extensions": ["ini"]
+    "extensions": ["ini", "toml"]
   },
   "text/richtext": {
     "compressible": true


### PR DESCRIPTION
Stellar exchanges need to read stellar.toml files as text/plain (see https://developers.stellar.org/docs/issuing-assets/publishing-asset-info/).