### PR TITLE
Add extensions for the "application/tar" type

### DIFF
--- a/src/custom-types.json
+++ b/src/custom-types.json
@@ -142,7 +142,12 @@
     ]
   },
   "application/tar": {
-    "compressible": true
+    "compressible": true,
+    "extensions": ["tar","tar.gz","taz","tgz"],
+    "sources": [
+      "https://www.gnu.org/software/tar/",
+      "https://en.wikipedia.org/wiki/Tar_(computing)"
+    ]
   },
   "application/toml": {
     "extensions": ["toml"],

--- a/src/custom-types.json
+++ b/src/custom-types.json
@@ -145,8 +145,7 @@
     "compressible": true,
     "extensions": ["tar","tar.gz","taz","tgz"],
     "sources": [
-      "https://www.gnu.org/software/tar/",
-      "https://en.wikipedia.org/wiki/Tar_(computing)"
+      "https://www.gnu.org/software/tar/"
     ]
   },
   "application/toml": {


### PR DESCRIPTION
Extensions like "tgz" is commonly used, for example, the "[npm pack](https://docs.npmjs.com/cli/v7/commands/npm-pack)" command generates a .tgz archive.

But these extensions related to the "application/tar" type is not included by mime-db yet, so let's add them here.