### PR TITLE
Add extension for TriG

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,6 +1,7 @@
 unreleased
 ==========
 
+  * Add extension `.trig` to `application/trig`
   * Add new upstream MIME types
 
 1.48.0 / 2021-05-30

--- a/db.json
+++ b/db.json
@@ -1643,7 +1643,8 @@
     "source": "iana"
   },
   "application/trig": {
-    "source": "iana"
+    "source": "iana",
+    "extensions": ["trig"]
   },
   "application/ttml+xml": {
     "source": "iana",

--- a/scripts/fetch-iana.js
+++ b/scripts/fetch-iana.js
@@ -32,7 +32,7 @@ var MIME_TYPE_HAS_CHARSET_PARAMETER_REGEXP = /parameters\s*:[^.]*\bcharset\b/im
 
 co(function * () {
   var gens = yield [
-    get('application', { extensions: /(?:\/(?:ecmascript|gzip|ld\+json|n-quads|n-triples|vnd\.(?:apple\..+|dbf|mapbox-vector-tile|rar))|\+xml)$/ }),
+    get('application', { extensions: /(?:\/(?:ecmascript|gzip|ld\+json|n-quads|n-triples|trig|vnd\.(?:apple\..+|dbf|mapbox-vector-tile|rar))|\+xml)$/ }),
     get('audio', { extensions: /\/mobile-xmf$/ }),
     get('font', { extensions: true }),
     get('image', { extensions: true }),

--- a/src/iana-types.json
+++ b/src/iana-types.json
@@ -2328,6 +2328,7 @@
     ]
   },
   "application/trig": {
+    "extensions": ["trig"],
     "sources": [
       "http://www.iana.org/assignments/media-types/application/trig"
     ]


### PR DESCRIPTION
As described in the W3C Recommendation:

> The Internet Media Type / MIME Type for TriG is "application/trig".
> 
> It is recommended that TriG files have the extension ".trig" (all lowercase) on all platforms.

—https://www.w3.org/TR/trig/#sec-mediaReg