### PR TITLE
Add file extensions for video/mp2t type

### DIFF
--- a/src/custom-types.json
+++ b/src/custom-types.json
@@ -858,6 +858,9 @@
   "video/mpeg": {
     "compressible": false
   },
+  "video/mp2t": {
+    "extensions": ["tsv", "tsa", "m2t", "m2ts"]
+  },
   "video/ogg": {
     "compressible": false
   },


### PR DESCRIPTION
While using https://github.com/jshttp/mime-types I noticed that it fails to perform lookup for `*.m2ts` files. Once this PR gets merged, published, and `mime-types` is updated to use the updated version of mime-db the problem should be resolved. 

