### PR TITLE
Added deprecated iWorks content types with extensions

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,6 +1,9 @@
 unreleased
 ==========
 
+  * Add `application/x-iwork-keynote-sffkey`
+  * Add `application/x-iwork-numbers-sffnumbers`
+  * Add `application/x-iwork-pages-sffpages`
   * Add new upstream MIME types
 
 1.49.0 / 2021-07-26

--- a/db.json
+++ b/db.json
@@ -5805,6 +5805,15 @@
     "source": "apache",
     "extensions": ["iso"]
   },
+  "application/x-iwork-keynote-sffkey": {
+    "extensions": ["key"]
+  },
+  "application/x-iwork-numbers-sffnumbers": {
+    "extensions": ["numbers"]
+  },
+  "application/x-iwork-pages-sffpages": {
+    "extensions": ["pages"]
+  },
   "application/x-java-archive-diff": {
     "source": "nginx",
     "extensions": ["jardiff"]

--- a/src/custom-types.json
+++ b/src/custom-types.json
@@ -293,6 +293,27 @@
       "http://php.net/manual/en/faq.installation.php"
     ]
   },
+  "application/x-iwork-keynote-sffkey": {
+    "extensions": ["key"],
+    "notes": "Deprecated alias for iWorks Keynote file",
+    "sources": [
+      "https://www.iana.org/assignments/media-types/application/vnd.apple.keynote"
+    ]
+  },
+  "application/x-iwork-numbers-sffnumbers": {
+    "extensions": ["numbers"],
+    "notes": "Deprecated alias for iWorks Numbers file",
+    "sources": [
+      "https://www.iana.org/assignments/media-types/application/vnd.apple.numbers"
+    ]
+  },
+  "application/x-iwork-pages-sffpages": {
+    "extensions": ["pages"],
+    "notes": "Deprecated alias for iWorks Pages file",
+    "sources": [
+      "https://www.iana.org/assignments/media-types/application/vnd.apple.pages"
+    ]
+  },
   "application/x-java-jnlp-file": {
     "compressible": false
   },


### PR DESCRIPTION
They are deprecated but I've found places still return them (Google Drive API being one).

Reference from (under _Additional information_):
https://www.iana.org/assignments/media-types/application/vnd.apple.keynote
https://www.iana.org/assignments/media-types/application/vnd.apple.numbers
https://www.iana.org/assignments/media-types/application/vnd.apple.pages

I've also updated the _unreleased_ section of the `HISTORY.md` - hope that's ok!