### PR TITLE
Indicate that .DDS textures are compressible

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -3,6 +3,7 @@ unreleased
 
   * Add new upstream MIME types
   * Mark `image/vnd.microsoft.icon` as compressible
+  * Mark `image/vnd.ms-dds` as compressible
 
 1.50.0 / 2021-09-15
 ===================

--- a/db.json
+++ b/db.json
@@ -7214,6 +7214,7 @@
     "source": "iana"
   },
   "image/vnd.ms-dds": {
+    "compressible": true,
     "extensions": ["dds"]
   },
   "image/vnd.ms-modi": {

--- a/src/custom-types.json
+++ b/src/custom-types.json
@@ -641,6 +641,7 @@
     ]
   },
   "image/vnd.ms-dds" : {
+    "compressible": true,
     "extensions": ["dds"],
     "notes": "Microsoft format for storing graphical textures and cubemaps. Used in 3d engines, such as Babylon.js.",
     "sources": [


### PR DESCRIPTION
I'm working with some large .DDS image-based lighting (IBL) textures, and found that my static server isn't compressing them (via [`compressible`](https://www.npmjs.com/package/compressible)). DDS is a container format for various GPU texture compression formats and I can't be sure that all variations benefit from compression, but the samples I have go from 8MB → 1.2MB with gzip. IBL files can get pretty large, so I think this is likely to be preferable for most WebGL/WebGPU applications.

/cc @the-simian (author of #170)