### PR TITLE
Ensure image/vnd.microsoft.icon is marked as compressible

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -2,6 +2,7 @@ unreleased
 ==========
 
   * Add new upstream MIME types
+  * Mark `image/vnd.microsoft.icon` as compressible
 
 1.50.0 / 2021-09-15
 ===================

--- a/db.json
+++ b/db.json
@@ -7204,6 +7204,7 @@
   },
   "image/vnd.microsoft.icon": {
     "source": "iana",
+    "compressible": true,
     "extensions": ["ico"]
   },
   "image/vnd.mix": {

--- a/src/custom-types.json
+++ b/src/custom-types.json
@@ -633,6 +633,13 @@
   "image/vnd.adobe.photoshop": {
     "compressible": true
   },
+  "image/vnd.microsoft.icon": {
+    "notes": "Alias for image/x-icon which is compressible",
+    "compressible": true,
+    "sources": [
+      "https://www.iana.org/assignments/media-types/image/vnd.microsoft.icon"
+    ]
+  },
   "image/vnd.ms-dds" : {
     "extensions": ["dds"],
     "notes": "Microsoft format for storing graphical textures and cubemaps. Used in 3d engines, such as Babylon.js.",


### PR DESCRIPTION
Hi, this updates `image/vnd.microsoft.icon` to be marked as `compressible` as `image/x-icon` is already marked as compressible and according to the doc [from IANA](https://www.iana.org/assignments/media-types/image/vnd.microsoft.icon) they are the same although `image/x-icon` seems to be used more commonly. The source used for `image/x-icon` also mentions the `image/vnd.microsoft.icon` type being used [here](http://en.wikipedia.org/wiki/ICO_(file_format)).
