### PR TITLE
Added the `wav` extension to `audio/vnd.wave`

### DIFF
--- a/db.json
+++ b/db.json
@@ -6850,8 +6850,7 @@
     "source": "iana"
   },
   "audio/vnd.wave": {
-    "compressible": false,
-    "extensions": ["wav"]
+    "compressible": false
   },
   "audio/vorbis": {
     "source": "iana",

--- a/db.json
+++ b/db.json
@@ -6850,7 +6850,8 @@
     "source": "iana"
   },
   "audio/vnd.wave": {
-    "compressible": false
+    "compressible": false,
+    "extensions": ["wav"]
   },
   "audio/vorbis": {
     "source": "iana",

--- a/src/custom-types.json
+++ b/src/custom-types.json
@@ -504,7 +504,8 @@
     "compressible": false,
     "extensions": ["wav"],
     "sources": [
-      "https://www.loc.gov/preservation/digital/formats/fdd/fdd000001.shtml"
+      "https://www.loc.gov/preservation/digital/formats/fdd/fdd000001.shtml",
+      "https://bugs.webkit.org/show_bug.cgi?id=173635"
     ]
   },
   "audio/vorbis": {

--- a/src/custom-types.json
+++ b/src/custom-types.json
@@ -501,7 +501,8 @@
     "compressible": false
   },
   "audio/vnd.wave": {
-    "compressible": false
+    "compressible": false,
+    "extensions": ["wav"]
   },
   "audio/vorbis": {
     "compressible": false

--- a/src/custom-types.json
+++ b/src/custom-types.json
@@ -502,7 +502,10 @@
   },
   "audio/vnd.wave": {
     "compressible": false,
-    "extensions": ["wav"]
+    "extensions": ["wav"],
+    "sources": [
+      "https://www.loc.gov/preservation/digital/formats/fdd/fdd000001.shtml"
+    ]
   },
   "audio/vorbis": {
     "compressible": false

--- a/src/custom-types.json
+++ b/src/custom-types.json
@@ -504,8 +504,7 @@
     "compressible": false,
     "extensions": ["wav"],
     "sources": [
-      "https://www.loc.gov/preservation/digital/formats/fdd/fdd000001.shtml",
-      "https://bugs.webkit.org/show_bug.cgi?id=173635"
+      "https://datatracker.ietf.org/doc/html/rfc2361"
     ]
   },
   "audio/vorbis": {


### PR DESCRIPTION
Resolves issues with https://github.com/oakserver/media_types/pull/12