### PR TITLE
Replace deprecated String.prototype.substr()

### DIFF
--- a/scripts/build.js
+++ b/scripts/build.js
@@ -25,7 +25,7 @@ Object.keys(mime).forEach(function (suffix) {
   var s = mime[suffix]
 
   Object.keys(db).forEach(function (type) {
-    if (type.substr(0 - suffix.length) !== suffix) {
+    if (type.slice(-suffix.length) !== suffix) {
       return
     }
 

--- a/scripts/fetch-apache.js
+++ b/scripts/fetch-apache.js
@@ -43,7 +43,7 @@ get(URL, function onResponse (err, body) {
   while ((match = TYPE_LINE_REGEXP.exec(body))) {
     var mime = match[1]
 
-    if (mime.substr(-8) === '/example') {
+    if (mime.slice(-8) === '/example') {
       continue
     }
 

--- a/scripts/fetch-iana.js
+++ b/scripts/fetch-iana.js
@@ -184,9 +184,9 @@ function extractTemplateMime (body) {
     return
   }
 
-  if (subtype.substr(0, type.length + 1) === type + '/') {
+  if (subtype.slice(0, type.length + 1) === type + '/') {
     // strip type from subtype
-    subtype = subtype.substr(type.length + 1)
+    subtype = subtype.slice(type.length + 1)
   }
 
   return (type + '/' + subtype).toLowerCase()
@@ -311,7 +311,7 @@ function addSource (data, url) {
 
 function appendToLine (line, str) {
   var trimmed = line.trimRight()
-  var append = trimmed.substr(-1) === '-'
+  var append = trimmed.slice(-1) === '-'
     ? str.trimLeft()
     : ' ' + str.trimLeft()
   return trimmed + append
@@ -374,7 +374,7 @@ function mimeEql (mime1, mime2) {
 }
 
 function normalizeHeader (val) {
-  return val.substr(0, 1).toLowerCase() + val.substr(1).replace(/ (.)/, function (s, c) {
+  return val.slice(0, 1).toLowerCase() + val.slice(1).replace(/ (.)/, function (s, c) {
     return c.toUpperCase()
   })
 }


### PR DESCRIPTION
[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.