### PR TITLE
Correct JavaScript MIME types + extensions per RFC 9239

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -5,6 +5,7 @@ unreleased
   * Add extensions from IANA for more MIME types
   * Add new upstream MIME types
   * Fix extensions for `text/markdown` to match IANA
+  * Remove extension `.mjs` from `application/javascript`
   * Remove obsolete MIME types from IANA data
 
 1.52.0 / 2022-02-21

--- a/db.json
+++ b/db.json
@@ -735,7 +735,7 @@
     "source": "apache",
     "charset": "UTF-8",
     "compressible": true,
-    "extensions": ["js","mjs"]
+    "extensions": ["js"]
   },
   "application/jf2feed+json": {
     "source": "iana",
@@ -7859,6 +7859,7 @@
   },
   "text/javascript": {
     "source": "iana",
+    "charset": "UTF-8",
     "compressible": true,
     "extensions": ["js","mjs"]
   },

--- a/src/custom-types.json
+++ b/src/custom-types.json
@@ -63,11 +63,7 @@
   },
   "application/javascript": {
     "charset": "UTF-8",
-    "compressible": true,
-    "extensions": ["mjs"],
-    "sources": [
-      "https://tools.ietf.org/html/draft-bfarias-javascript-mjs-00"
-    ]
+    "compressible": true
   },
   "application/json": {
     "charset": "UTF-8",
@@ -757,7 +753,11 @@
     "extensions": ["jade"]
   },
   "text/javascript": {
-    "compressible": true
+    "charset": "UTF-8",
+    "compressible": true,
+    "sources": [
+      "https://www.rfc-editor.org/rfc/rfc9239"
+    ]
   },
   "text/jsx": {
     "compressible": true,


### PR DESCRIPTION
This patch updates the MIME type configuration per RFC 9239.
https://www.rfc-editor.org/rfc/rfc9239

First, the recommended MIME type is now `text/javascript`:

> The most widely supported media type in use is `text/javascript`; all
> others are considered historical and obsolete aliases of `text/javascript`.

Second, the `.mjs` extension is now explicitly registered:

> The `.mjs` file extension signals that the file represents a JavaScript
> module. Execution environments that rely on file extensions to
> determine how to process inputs parse `.mjs` files using the Module
> grammar of [ECMA-262].

(mime-db already included the `.mjs` extension prior to this patch, so no
change needed here.)

IANA template: https://www.iana.org/assignments/media-types/text/javascript