### PR TITLE
Add application/importmap+json

### DIFF
--- a/db.json
+++ b/db.json
@@ -678,6 +678,10 @@
     "charset": "UTF-8",
     "compressible": true
   },
+  "application/importmap+json": {
+    "compressible": true,
+    "extensions": ["importmap"]
+  },
   "application/index": {
     "source": "iana"
   },

--- a/src/custom-types.json
+++ b/src/custom-types.json
@@ -52,6 +52,13 @@
       "https://hjson.org/rfc.html#rfc.section.1.3"
     ]
   },
+  "application/importmap+json": {
+    "extensions": ["importmap"],
+    "sources": [
+      "https://github.com/WICG/import-maps#installation",
+      "https://wicg.github.io/import-maps/#comparison-with-first-party-scripts"
+    ]
+  },
   "application/java-archive": {
     "compressible": false
   },


### PR DESCRIPTION
External Import maps require a specific MIME-type, here is the link to [ W3C](https://wicg.github.io/import-maps/) and to [WICG](https://github.com/WICG/import-maps)