### PR TITLE
add jfif to image/jpeg

### DIFF
--- a/db.json
+++ b/db.json
@@ -7176,7 +7176,7 @@
   "image/jpeg": {
     "source": "iana",
     "compressible": false,
-    "extensions": ["jpeg","jpg","jpe"]
+    "extensions": ["jpeg","jpg","jpe", "jfif"]
   },
   "image/jph": {
     "source": "iana",


### PR DESCRIPTION
"jfif" is missing as a file-type for image/jpeg 
https://www.w3.org/Graphics/JPEG/