### PR TITLE
fix: Mark text/x-component as compressible

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -11,6 +11,7 @@ unreleased
   * Fix extensions for `text/markdown` to match IANA
   * Remove extension `.mjs` from `application/javascript`
   * Remove obsolete MIME types from IANA data
+  * Mark `text/x-component` as compressible
 
 1.52.0 / 2022-02-21
 ===================

--- a/db.json
+++ b/db.json
@@ -8305,6 +8305,7 @@
   },
   "text/x-component": {
     "source": "nginx",
+    "compressible": true,
     "extensions": ["htc"]
   },
   "text/x-fortran": {


### PR DESCRIPTION
According to https://en.wikipedia.org/wiki/HTML_Components and other resources, `text/x-component` (`.htc` file) is plain text in XML and also very similar to HTML, and it is compressible.