### PR TITLE
Add jpe,jif,jfif as image/jpeg mime type

### DIFF
--- a/src/custom-types.json
+++ b/src/custom-types.json
@@ -634,7 +634,11 @@
     ]
   },
   "image/jpeg": {
-    "compressible": false
+    "compressible": false,
+    "extensions": ["jpe", "jif", "jfif"],
+    "sources": [
+      "https://developer.mozilla.org/en-US/docs/Web/Media/Formats/Image_types#jpeg_joint_photographic_experts_group_image"
+    ]
   },
   "image/jpm": {
     "compressible": false,


### PR DESCRIPTION
jfif is the only one that I have actual files for, but for completeness based on https://developer.mozilla.org/en-US/docs/Web/Media/Formats/Image_types#jpeg_joint_photographic_experts_group_image I included jpe and jif.

Fix for #283 