### PR TITLE
Added extensions list for model/step

### DIFF
--- a/src/custom-types.json
+++ b/src/custom-types.json
@@ -725,7 +725,7 @@
   },
   "model/step": {
     "extensions": ["step", "stp", "stpnc", "p21", "210"],
-    "3D model format. Used in CAD.",
+    "notes": "3D model format. Used in CAD.",
     "sources": [
       "https://www.iana.org/assignments/media-types/model/step"
     ]


### PR DESCRIPTION
model/step was missing the extensions list. I added the extensions listed here: https://www.iana.org/assignments/media-types/model/step

Fix for #292 