### PR TITLE
Update iana-types.json

### DIFF
--- a/src/iana-types.json
+++ b/src/iana-types.json
@@ -605,6 +605,7 @@
     ]
   },
   "application/dicom": {
+    "extensions": ["dcm"],
     "sources": [
       "https://tools.ietf.org/rfc/rfc3240.txt",
       "https://www.iana.org/assignments/media-types/application/dicom"


### PR DESCRIPTION
Add 'dcm' extension to application/dicom mime. 'dcm' is the recommended extension for this multimedia type as stated at point 2 of additional information in this iana.org page https://www.iana.org/assignments/media-types/application/dicom.