### PR TITLE
(Experimental) Add ESM support

### DIFF
--- a/.github/workflows/esm.yml
+++ b/.github/workflows/esm.yml
@@ -1,0 +1,18 @@
+name: esm ci
+
+on:
+  - pull_request
+  - push
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        version: [16.14, 18, 20]
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.version }}
+      - run: node test/esm.mjs

--- a/.github/workflows/esm.yml
+++ b/.github/workflows/esm.yml
@@ -8,7 +8,7 @@ jobs:
   build:
     strategy:
       matrix:
-        version: [16.14, 18, 20]
+        version: [18, 20]
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/esm.yml
+++ b/.github/workflows/esm.yml
@@ -15,4 +15,5 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.version }}
+      - run: npm install
       - run: node test/esm.mjs

--- a/index.mjs
+++ b/index.mjs
@@ -1,0 +1,1 @@
+export { default } from "./db.json" assert { type: "json" }

--- a/package.json
+++ b/package.json
@@ -2,6 +2,8 @@
   "name": "mime-db",
   "description": "Media Type Database",
   "version": "1.52.0",
+  "main": "index.js",
+  "module": "index.mjs",
   "contributors": [
     "Douglas Christopher Wilson <doug@somethingdoug.com>",
     "Jonathan Ong <me@jongleberry.com> (http://jongleberry.com)",
@@ -38,16 +40,18 @@
     "LICENSE",
     "README.md",
     "db.json",
-    "index.js"
+    "index.js",
+    "index.mjs"
   ],
   "engines": {
-    "node": ">= 0.6"
+    "node": "^16.14 || 18 || 20"
   },
   "scripts": {
     "build": "node scripts/build",
     "fetch": "node scripts/fetch-apache && node scripts/fetch-iana && node scripts/fetch-nginx",
     "lint": "eslint .",
-    "test": "mocha --reporter spec --bail --check-leaks test/",
+    "test": "mocha --reporter spec --bail --check-leaks test/**/*.js",
+    "test:esm": "node test/esm.mjs",
     "test-ci": "nyc --reporter=lcovonly --reporter=text npm test",
     "test-cov": "nyc --reporter=html --reporter=text npm test",
     "update": "npm run fetch && npm run build",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "index.mjs"
   ],
   "engines": {
-    "node": "^16.14 || 18 || 20"
+    "node": "18 || 20"
   },
   "scripts": {
     "build": "node scripts/build",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "index.mjs"
   ],
   "engines": {
-    "node": "18 || 20"
+    "node": ">= 0.6"
   },
   "scripts": {
     "build": "node scripts/build",

--- a/package.json
+++ b/package.json
@@ -4,6 +4,13 @@
   "version": "1.52.0",
   "main": "index.js",
   "module": "index.mjs",
+  "sideEffects": false,
+  "exports": {
+    ".": {
+      "require": "./index.js",
+      "import": "./index.mjs"
+    }
+  },
   "contributors": [
     "Douglas Christopher Wilson <doug@somethingdoug.com>",
     "Jonathan Ong <me@jongleberry.com> (http://jongleberry.com)",

--- a/test/esm.mjs
+++ b/test/esm.mjs
@@ -1,0 +1,77 @@
+import assert from "node:assert"
+import { readdirSync } from "node:fs"
+import { resolve } from "node:path"
+import { fileURLToPath } from "node:url"
+import test from 'node:test';
+
+import typer from "media-typer"
+
+import db from  "../index.mjs"
+
+const __dirname = fileURLToPath(new URL('.', import.meta.url));
+const path = resolve(__dirname, '..', 'src')
+const types = []
+
+test("should not contain types not in src", async () => {
+  // collect all source types
+  for (const file of readdirSync(path)) {
+    if (!/-types\.json$/.test(file)) continue
+
+    const imported = await import(resolve(path, file), {
+      assert: {
+        type: "json"
+      }
+    })
+    types.push(...Object.keys(imported.default))
+  }
+
+  Object.keys(db).forEach((name) => {
+    assert.ok(types.includes(name), `type ${name} should be in src/`)
+  })
+})
+
+test("should contain only valid mime types", () => {
+  Object.keys(db).forEach((mime) => {
+    assert.ok(typer.test(mime), `type ${mime} is a valid mime type`)
+  })
+})
+
+test("should not have any uppercased letters in names", () => {
+  Object.keys(db).forEach((name) => {
+    assert.strictEqual(name, name.toLowerCase(), `type ${name} should be lowercase`)
+  })
+})
+
+test("should have .json and .js as having UTF-8 charsets", () => {
+  assert.strictEqual('UTF-8', db['application/json'].charset)
+  assert.strictEqual('UTF-8', db['application/javascript'].charset)
+})
+
+test("should set audio/x-flac with extension=flac", () => {
+  assert.strictEqual('flac', db['audio/x-flac'].extensions[0], 'should set audio/x-flac with extension=flac')
+})
+
+test("should have guessed application/mathml+xml", () => {
+  assert(db['application/mathml+xml'])
+})
+
+test("should not have an empty .extensions", () => {
+  assert(Object.keys(db).every((name) => {
+    var mime = db[name]
+    if (!mime.extensions) return true
+    return mime.extensions.length
+  }))
+})
+
+test("should have only lowercase .extensions", () => {
+  Object.keys(db).forEach((name) => {
+    (db[name].extensions || []).forEach((ext) => {
+      assert.strictEqual(ext, ext.toLowerCase(), `extension ${ext} in type ${name} should be lowercase`)
+    })
+  })
+})
+
+test("should have the default .extension as the first", () => {
+  assert.strictEqual(db['text/plain'].extensions[0], 'txt')
+  assert.strictEqual(db['video/x-matroska'].extensions[0], 'mkv')
+})


### PR DESCRIPTION
This PR adds ESM support by adding an `index.mjs` file and the appropiate package.json field (`module`), I also added [`exports`](https://nodejs.org/api/packages.html#conditional-exports). The import uses the **experimental** JSON module syntax (https://nodejs.org/api/esm.html#json-modules), which requires Node 16.14+.

I also added a Github workflow and a new test file that uses Node's test runner. FWIW, the tests merged at some point in the future.

---

An alternative would be to use `createRequire`, but it does not seem well supported by bundlers:
https://github.com/evanw/esbuild/issues/1828
https://github.com/rollup/rollup/issues/4274

---

Another alternative would be to just drop CommonJS altogether, and only provide a ESM export, dropping Node 0 - 16.13 support, and bumping one major version to mime-db@2.0.0. After all, everything up to Node 14 has reached EOL, even Node 16 is [getting close](https://endoflife.date/nodejs). That way, the `engines` field in the package.json could also be adjusted appropiately.

Maybe some years down the line...

---

PS: It's 2023, I think it's OK to drop some old Node versions and io.js from the CI :)
It could be massively simplified by just using a node-version matrix entry and the setup-node GH action.