### PR TITLE
Fix typo found by codespell: text/calender

### DIFF
--- a/src/custom-types.json
+++ b/src/custom-types.json
@@ -755,13 +755,6 @@
       "https://bugzilla.mozilla.org/show_bug.cgi?id=715191#c2"
     ]
   },
-  "text/calender": {
-    "compressible": true,
-    "notes": "Probably needs to be uncompressed before sent to iCalender.",
-    "sources": [
-      "http://en.wikipedia.org/wiki/ICalendar"
-    ]
-  },
   "text/cmd": {
     "compressible": true
   },


### PR DESCRIPTION
Also, iCalend**e**r is obviously iCalend**a**r, as shown by this link:
	http://en.wikipedia.org/wiki/ICalendar

The above link only refers to `text/calendar`.

The real mime type is `text/calendar`, and has been in the database since its inception, see `src/iana-types.json`.

Fixes  #301.