### PR TITLE
Add Google Drive MIME types

### DIFF
--- a/src/custom-types.json
+++ b/src/custom-types.json
@@ -210,7 +210,7 @@
     "compressible": false,
     "extensions": ["gdoc"],
     "sources": [
-      "https://developers.google.com/drive/v2/web/mime-types",
+      "https://developers.google.com/drive/api/guides/mime-types",
       "https://support.google.com/drive/answer/2374983?hl=en"
     ]
   },
@@ -218,7 +218,7 @@
     "compressible": false,
     "extensions": ["gslides"],
     "sources": [
-      "https://developers.google.com/drive/v2/web/mime-types",
+      "https://developers.google.com/drive/api/guides/mime-types",
       "https://support.google.com/drive/answer/2374983?hl=en"
     ]
   },
@@ -226,7 +226,7 @@
     "compressible": false,
     "extensions": ["gsheet"],
     "sources": [
-      "https://developers.google.com/drive/v2/web/mime-types",
+      "https://developers.google.com/drive/api/guides/mime-types",
       "https://support.google.com/drive/answer/2374983?hl=en"
     ]
   },

--- a/src/custom-types.json
+++ b/src/custom-types.json
@@ -207,7 +207,6 @@
     "compressible": true
   },
   "application/vnd.google-apps.audio": {
-    "compressible": false,
     "sources": [
       "https://developers.google.com/drive/api/guides/mime-types",
       "https://support.google.com/drive/answer/2374983?hl=en"
@@ -237,7 +236,6 @@
     ]
   },
   "application/vnd.google-apps.file": {
-    "compressible": false,
     "sources": [
       "https://developers.google.com/drive/api/guides/mime-types",
       "https://support.google.com/drive/answer/2374983?hl=en"
@@ -259,7 +257,6 @@
     ]
   },
   "application/vnd.google-apps.fusiontable": {
-    "compressible": false,
     "sources": [
       "https://developers.google.com/drive/api/guides/mime-types",
       "https://support.google.com/drive/answer/2374983?hl=en"
@@ -274,7 +271,6 @@
     ]
   },
   "application/vnd.google-apps.mail-layout": {
-    "compressible": false,
     "sources": [
       "https://developers.google.com/drive/api/guides/mime-types",
       "https://support.google.com/drive/answer/2374983?hl=en"
@@ -289,7 +285,6 @@
     ]
   },
   "application/vnd.google-apps.photo": {
-    "compressible": false,
     "sources": [
       "https://developers.google.com/drive/api/guides/mime-types",
       "https://support.google.com/drive/answer/2374983?hl=en"
@@ -312,7 +307,6 @@
     ]
   },
   "application/vnd.google-apps.shortcut": {
-    "compressible": false,
     "sources": [
       "https://developers.google.com/drive/api/guides/mime-types",
       "https://support.google.com/drive/answer/2374983?hl=en"
@@ -335,14 +329,12 @@
     ]
   },
   "application/vnd.google-apps.unknown": {
-    "compressible": false,
     "sources": [
       "https://developers.google.com/drive/api/guides/mime-types",
       "https://support.google.com/drive/answer/2374983?hl=en"
     ]
   },
   "application/vnd.google-apps.video": {
-    "compressible": false,
     "sources": [
       "https://developers.google.com/drive/api/guides/mime-types",
       "https://support.google.com/drive/answer/2374983?hl=en"

--- a/src/custom-types.json
+++ b/src/custom-types.json
@@ -206,9 +206,90 @@
   "application/vnd.dart": {
     "compressible": true
   },
+  "application/vnd.google-apps.audio": {
+    "compressible": false,
+    "sources": [
+      "https://developers.google.com/drive/api/guides/mime-types",
+      "https://support.google.com/drive/answer/2374983?hl=en"
+    ]
+  },
   "application/vnd.google-apps.document": {
     "compressible": false,
     "extensions": ["gdoc"],
+    "sources": [
+      "https://developers.google.com/drive/api/guides/mime-types",
+      "https://support.google.com/drive/answer/2374983?hl=en"
+    ]
+  },
+  "application/vnd.google-apps.drive-sdk": {
+    "compressible": false,
+    "sources": [
+      "https://developers.google.com/drive/api/guides/mime-types",
+      "https://support.google.com/drive/answer/2374983?hl=en"
+    ]
+  },
+  "application/vnd.google-apps.drawing": {
+    "compressible": false,
+    "extensions": ["gdraw"],
+    "sources": [
+      "https://developers.google.com/drive/api/guides/mime-types",
+      "https://support.google.com/drive/answer/2374983?hl=en"
+    ]
+  },
+  "application/vnd.google-apps.file": {
+    "compressible": false,
+    "sources": [
+      "https://developers.google.com/drive/api/guides/mime-types",
+      "https://support.google.com/drive/answer/2374983?hl=en"
+    ]
+  },
+  "application/vnd.google-apps.folder": {
+    "compressible": false,
+    "sources": [
+      "https://developers.google.com/drive/api/guides/mime-types",
+      "https://support.google.com/drive/answer/2374983?hl=en"
+    ]
+  },
+  "application/vnd.google-apps.form": {
+    "compressible": false,
+    "extensions": ["gform"],
+    "sources": [
+      "https://developers.google.com/drive/api/guides/mime-types",
+      "https://support.google.com/drive/answer/2374983?hl=en"
+    ]
+  },
+  "application/vnd.google-apps.fusiontable": {
+    "compressible": false,
+    "sources": [
+      "https://developers.google.com/drive/api/guides/mime-types",
+      "https://support.google.com/drive/answer/2374983?hl=en"
+    ]
+  },
+  "application/vnd.google-apps.jam": {
+    "compressible": false,
+    "extensions": ["gjam"],
+    "sources": [
+      "https://developers.google.com/drive/api/guides/mime-types",
+      "https://support.google.com/drive/answer/2374983?hl=en"
+    ]
+  },
+  "application/vnd.google-apps.mail-layout": {
+    "compressible": false,
+    "sources": [
+      "https://developers.google.com/drive/api/guides/mime-types",
+      "https://support.google.com/drive/answer/2374983?hl=en"
+    ]
+  },
+  "application/vnd.google-apps.map": {
+    "compressible": false,
+    "extensions": ["gmap"],
+    "sources": [
+      "https://developers.google.com/drive/api/guides/mime-types",
+      "https://support.google.com/drive/answer/2374983?hl=en"
+    ]
+  },
+  "application/vnd.google-apps.photo": {
+    "compressible": false,
     "sources": [
       "https://developers.google.com/drive/api/guides/mime-types",
       "https://support.google.com/drive/answer/2374983?hl=en"
@@ -222,9 +303,46 @@
       "https://support.google.com/drive/answer/2374983?hl=en"
     ]
   },
+  "application/vnd.google-apps.script": {
+    "compressible": false,
+    "extensions": ["gscript"],
+    "sources": [
+      "https://developers.google.com/drive/api/guides/mime-types",
+      "https://support.google.com/drive/answer/2374983?hl=en"
+    ]
+  },
+  "application/vnd.google-apps.shortcut": {
+    "compressible": false,
+    "sources": [
+      "https://developers.google.com/drive/api/guides/mime-types",
+      "https://support.google.com/drive/answer/2374983?hl=en"
+    ]
+  },
+  "application/vnd.google-apps.site": {
+    "compressible": false,
+    "extensions": ["gsite"],
+    "sources": [
+      "https://developers.google.com/drive/api/guides/mime-types",
+      "https://support.google.com/drive/answer/2374983?hl=en"
+    ]
+  },
   "application/vnd.google-apps.spreadsheet": {
     "compressible": false,
     "extensions": ["gsheet"],
+    "sources": [
+      "https://developers.google.com/drive/api/guides/mime-types",
+      "https://support.google.com/drive/answer/2374983?hl=en"
+    ]
+  },
+  "application/vnd.google-apps.unknown": {
+    "compressible": false,
+    "sources": [
+      "https://developers.google.com/drive/api/guides/mime-types",
+      "https://support.google.com/drive/answer/2374983?hl=en"
+    ]
+  },
+  "application/vnd.google-apps.video": {
+    "compressible": false,
     "sources": [
       "https://developers.google.com/drive/api/guides/mime-types",
       "https://support.google.com/drive/answer/2374983?hl=en"

--- a/src/custom-types.json
+++ b/src/custom-types.json
@@ -215,6 +215,7 @@
   "application/vnd.google-apps.document": {
     "compressible": false,
     "extensions": ["gdoc"],
+    "notes": "Google Docs",
     "sources": [
       "https://developers.google.com/drive/api/guides/mime-types",
       "https://support.google.com/drive/answer/2374983?hl=en"
@@ -222,6 +223,7 @@
   },
   "application/vnd.google-apps.drive-sdk": {
     "compressible": false,
+    "notes": "Third-party shortcut",
     "sources": [
       "https://developers.google.com/drive/api/guides/mime-types",
       "https://support.google.com/drive/answer/2374983?hl=en"
@@ -230,12 +232,14 @@
   "application/vnd.google-apps.drawing": {
     "compressible": false,
     "extensions": ["gdraw"],
+    "notes": "Google Drawings",
     "sources": [
       "https://developers.google.com/drive/api/guides/mime-types",
       "https://support.google.com/drive/answer/2374983?hl=en"
     ]
   },
   "application/vnd.google-apps.file": {
+    "notes": "Google Drive file",
     "sources": [
       "https://developers.google.com/drive/api/guides/mime-types",
       "https://support.google.com/drive/answer/2374983?hl=en"
@@ -243,6 +247,7 @@
   },
   "application/vnd.google-apps.folder": {
     "compressible": false,
+    "notes": "Google Drive folder",
     "sources": [
       "https://developers.google.com/drive/api/guides/mime-types",
       "https://support.google.com/drive/answer/2374983?hl=en"
@@ -251,12 +256,14 @@
   "application/vnd.google-apps.form": {
     "compressible": false,
     "extensions": ["gform"],
+    "notes": "Google Forms",
     "sources": [
       "https://developers.google.com/drive/api/guides/mime-types",
       "https://support.google.com/drive/answer/2374983?hl=en"
     ]
   },
   "application/vnd.google-apps.fusiontable": {
+    "notes": "Google Fusion Tables",
     "sources": [
       "https://developers.google.com/drive/api/guides/mime-types",
       "https://support.google.com/drive/answer/2374983?hl=en"
@@ -265,12 +272,14 @@
   "application/vnd.google-apps.jam": {
     "compressible": false,
     "extensions": ["gjam"],
+    "notes": "Google Jamboard",
     "sources": [
       "https://developers.google.com/drive/api/guides/mime-types",
       "https://support.google.com/drive/answer/2374983?hl=en"
     ]
   },
   "application/vnd.google-apps.mail-layout": {
+    "notes": "Email layout",
     "sources": [
       "https://developers.google.com/drive/api/guides/mime-types",
       "https://support.google.com/drive/answer/2374983?hl=en"
@@ -279,12 +288,14 @@
   "application/vnd.google-apps.map": {
     "compressible": false,
     "extensions": ["gmap"],
+    "notes": "Google My Maps",
     "sources": [
       "https://developers.google.com/drive/api/guides/mime-types",
       "https://support.google.com/drive/answer/2374983?hl=en"
     ]
   },
   "application/vnd.google-apps.photo": {
+    "notes": "Google Photos",
     "sources": [
       "https://developers.google.com/drive/api/guides/mime-types",
       "https://support.google.com/drive/answer/2374983?hl=en"
@@ -293,6 +304,7 @@
   "application/vnd.google-apps.presentation": {
     "compressible": false,
     "extensions": ["gslides"],
+    "notes": "Google Slides",
     "sources": [
       "https://developers.google.com/drive/api/guides/mime-types",
       "https://support.google.com/drive/answer/2374983?hl=en"
@@ -301,12 +313,14 @@
   "application/vnd.google-apps.script": {
     "compressible": false,
     "extensions": ["gscript"],
+    "notes": "Google Apps Script",
     "sources": [
       "https://developers.google.com/drive/api/guides/mime-types",
       "https://support.google.com/drive/answer/2374983?hl=en"
     ]
   },
   "application/vnd.google-apps.shortcut": {
+    "notes": "Shortcut",
     "sources": [
       "https://developers.google.com/drive/api/guides/mime-types",
       "https://support.google.com/drive/answer/2374983?hl=en"
@@ -315,6 +329,7 @@
   "application/vnd.google-apps.site": {
     "compressible": false,
     "extensions": ["gsite"],
+    "notes": "Google Sites",
     "sources": [
       "https://developers.google.com/drive/api/guides/mime-types",
       "https://support.google.com/drive/answer/2374983?hl=en"
@@ -323,6 +338,7 @@
   "application/vnd.google-apps.spreadsheet": {
     "compressible": false,
     "extensions": ["gsheet"],
+    "notes": "Google Sheets",
     "sources": [
       "https://developers.google.com/drive/api/guides/mime-types",
       "https://support.google.com/drive/answer/2374983?hl=en"


### PR DESCRIPTION
This PR adds all the "Google Workspace and Google Drive supported MIME types."
reference: https://developers.google.com/drive/api/guides/mime-types
Note. The reference URL is updated since the source (https://developers.google.com/drive/v2/web/mime-types) in `custom-types.json` is redirected to the current one.

Initially, #38 added some of them, but I think the MIME types increased.

I copied `notes` from the reference. For `compressible`, I left them undefined unless they are apparent.

Some have `extensions`, as I found when I checked using Google Drive Desktop.
![image](https://github.com/jshttp/mime-db/assets/79110363/ce7f5e8f-f6a9-4a0c-a1d2-b966e15feb07)