### PR TITLE
fix: make `application/vnd.unity` compressible

### DIFF
--- a/db.json
+++ b/db.json
@@ -5530,6 +5530,7 @@
   },
   "application/vnd.unity": {
     "source": "iana",
+    "compressible": true,
     "extensions": ["unityweb"]
   },
   "application/vnd.uoml+xml": {


### PR DESCRIPTION
The Unity documentation mentions both gzip and brotli are recommended when serving `.unityweb` files.

https://docs.unity3d.com/Manual/webgl-deploying.html