### PR TITLE
Added `.gpkg` extension for `application/geopackage+sqlite3` from IANA

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,6 +1,7 @@
 unreleased
 ==========
 
+  * Add extension `gpkg.` to `application/geopackage+sqlite3`
   * Add extension `.sql` to `application/sql`
   * Add extensions `.aac` and `.adts` to `audio/aac`
   * Add extensions `.js` and `.mjs` to `text/javascript`

--- a/db.json
+++ b/db.json
@@ -641,7 +641,8 @@
     "source": "iana"
   },
   "application/geopackage+sqlite3": {
-    "source": "iana"
+    "source": "iana",
+    "extensions": ["gpkg"]
   },
   "application/geoxacml+xml": {
     "source": "iana",

--- a/scripts/fetch-iana.js
+++ b/scripts/fetch-iana.js
@@ -35,7 +35,7 @@ var MIME_TYPE_HAS_CHARSET_PARAMETER_REGEXP = /parameters\s*:[^.]*\bcharset\b/im
 
 ;(async function () {
   const results = Array.prototype.concat.apply([], [
-    await get('application', { extensions: /(?:\/(?:automationml-amlx?\+.+|cwl|ecmascript|express|fdf|gzip|(?:ld|manifest)\+json|mp4|n-quads|n-triples|pgp-.+|sql|trig|vnd\.(?:age|apple\..+|dbf|mapbox-vector-tile|rar))|xfdf|\+xml)$/ }),
+    await get('application', { extensions: /(?:\/(?:automationml-amlx?\+.+|cwl|ecmascript|express|fdf|geopackage\+sqlite3|gzip|(?:ld|manifest)\+json|mp4|n-quads|n-triples|pgp-.+|sql|trig|vnd\.(?:age|apple\..+|dbf|mapbox-vector-tile|rar))|xfdf|\+xml)$/ }),
     await get('audio', { extensions: /\/(?:aac|mobile-xmf)$/ }),
     await get('font', { extensions: true }),
     await get('image', { extensions: true }),

--- a/src/iana-types.json
+++ b/src/iana-types.json
@@ -912,6 +912,7 @@
     ]
   },
   "application/geopackage+sqlite3": {
+    "extensions": ["gpkg"],
     "sources": [
       "https://www.iana.org/assignments/media-types/application/geopackage+sqlite3"
     ]


### PR DESCRIPTION
Hello, this PR adds the extension `.gpkg` for GeoPackage files MIME type `application/geopackage+sqlite3`. The extension is defined by IANA here - https://www.iana.org/assignments/media-types/application/geopackage+sqlite3

The commit is more or less similar to what has been done in 48e411522aed9925570b6c6bbf0bbc331242c038.
