### PR TITLE
Add .blend file type

### DIFF
--- a/db.json
+++ b/db.json
@@ -6155,6 +6155,9 @@
     "source": "apache",
     "extensions": ["torrent"]
   },
+  "application/x-blender": {
+    "extensions": ["blend",".blend1",".blend2"]
+  },
   "application/x-blorb": {
     "source": "apache",
     "extensions": ["blb","blorb"]

--- a/db.json
+++ b/db.json
@@ -6155,9 +6155,6 @@
     "source": "apache",
     "extensions": ["torrent"]
   },
-  "application/x-blender": {
-    "extensions": ["blend",".blend1",".blend2"]
-  },
   "application/x-blorb": {
     "source": "apache",
     "extensions": ["blb","blorb"]

--- a/src/custom-types.json
+++ b/src/custom-types.json
@@ -308,6 +308,14 @@
       "http://www.id.ee/public/bdoc-spec21.pdf"
     ]
   },
+  "application/x-blender": {
+    "extensions": ["blend", ".blend1", ".blend2"],
+    "notes": "Blender's main project file format",
+    "sources": [
+      "https://www.loc.gov/preservation/digital/formats//fdd/fdd000559.shtml",
+      "https://archive.blender.org/wiki/2015/index.php/Dev:Source/Architecture/File_Format/"
+    ]
+  },
   "application/x-bzip": {
     "compressible": false
   },

--- a/src/custom-types.json
+++ b/src/custom-types.json
@@ -309,7 +309,7 @@
     ]
   },
   "application/x-blender": {
-    "extensions": ["blend", ".blend1", ".blend2"],
+    "extensions": ["blend"],
     "notes": "Blender's main project file format",
     "sources": [
       "https://www.loc.gov/preservation/digital/formats//fdd/fdd000559.shtml",


### PR DESCRIPTION
**Description:**
This PR adds the `application/x-blender` media type to the mime-db repository to support Blender’s native project file format, which is commonly used in 3D modeling and animation workflows. Blender files are saved with `.blend` extensions, along with versioned extensions such as `.blend1` and `.blend2`.

**Details:**
- **Media Type**: `application/x-blender`
- **Extensions**: `.blend`, `.blend1`, `.blend2`
- **Description**: Blender's main project file format
- **Sources**:
  - [Library of Congress Digital Formats](https://www.loc.gov/preservation/digital/formats//fdd/fdd000559.shtml)
  - [Blender File Format Documentation (Archived)](https://archive.blender.org/wiki/2015/index.php/Dev:Source/Architecture/File_Format/)