### PR TITLE
Add Procreate Brush and Brush Set file Types

### DIFF
--- a/db.json
+++ b/db.json
@@ -5241,12 +5241,6 @@
     "source": "iana",
     "extensions": ["box"]
   },
-  "application/vnd.procrate.brushset": {
-    "extensions": ["brushset"]
-  },
-  "application/vnd.procreate.brush": {
-    "extensions": ["brush"]
-  },
   "application/vnd.proteus.magazine": {
     "source": "iana",
     "extensions": ["mgz"]

--- a/db.json
+++ b/db.json
@@ -5241,6 +5241,12 @@
     "source": "iana",
     "extensions": ["box"]
   },
+  "application/vnd.procrate.brushset": {
+    "extensions": ["brushset"]
+  },
+  "application/vnd.procreate.brush": {
+    "extensions": ["brush"]
+  },
   "application/vnd.proteus.magazine": {
     "source": "iana",
     "extensions": ["mgz"]

--- a/src/custom-types.json
+++ b/src/custom-types.json
@@ -258,6 +258,20 @@
   "application/vnd.ms-xpsdocument": {
     "compressible": false
   },
+  "application/vnd.procreate.brush": {
+    "extensions": ["brush"],
+    "sources": [
+      "https://help.procreate.com/procreate/handbook/brushes/brushes-share"
+    ],
+    "notes": "Procreate Brush"
+  },
+  "application/vnd.procrate.brushset": {
+    "extensions": ["brushset"],
+    "sources": [
+      "https://help.procreate.com/procreate/handbook/brushes/brushes-share"
+    ],
+    "notes": "Procreate Brush Set"
+  },
   "application/vnd.oasis.opendocument.graphics": {
     "compressible": false
   },


### PR DESCRIPTION
#### Description
This PR introduces new MIME types for Procreate-specific file formats:
- **`application/vnd.procreate.brush`** for `.brush` files
- **`application/vnd.procreate.brushset`** for `.brushset` files

These MIME types correspond to Procreate’s custom brush and brush set formats, commonly used shared by artists and designers on the Procreate app.

#### Details
- **application/vnd.procreate.brush**  
  - **Extensions**: `.brush`
  - **Description**: Procreate Brush
  - **Sources**: [Procreate Handbook - Brush Sharing](https://help.procreate.com/procreate/handbook/brushes/brushes-share)
  
- **application/vnd.procreate.brushset**  
  - **Extensions**: `.brushset`
  - **Description**: Procreate Brush Set
  - **Sources**: [Procreate Handbook - Brush Sharing](https://help.procreate.com/procreate/handbook/brushes/brushes-share)

#### Notes:
The brushset file type is a collection of Brush files
