### PR TITLE
Add Adobe DNG file

### DIFF
--- a/db.json
+++ b/db.json
@@ -7842,9 +7842,6 @@
     "source": "apache",
     "extensions": ["3ds"]
   },
-  "image/x-adobe-dng": {
-    "extensions": ["dng"]
-  },
   "image/x-cmu-raster": {
     "source": "apache",
     "extensions": ["ras"]

--- a/db.json
+++ b/db.json
@@ -7842,6 +7842,9 @@
     "source": "apache",
     "extensions": ["3ds"]
   },
+  "image/x-adobe-dng": {
+    "extensions": ["dng"]
+  },
   "image/x-cmu-raster": {
     "source": "apache",
     "extensions": ["ras"]

--- a/src/custom-types.json
+++ b/src/custom-types.json
@@ -682,6 +682,13 @@
       "https://docs.microsoft.com/en-us/windows/win32/wic/dds-format-overview"
     ]
   },
+  "image/x-adobe-dng": {
+    "extensions": ["dng"],
+    "notes": "A non-proprietary file format for storing camera raw files",
+    "sources": [
+      "https://paulbourke.net/dataformats/dng/dng_spec_1_6_0_0.pdf"
+    ]
+  },
   "image/x-icon": {
     "compressible": true,
     "notes": "Usually a wrapper for .bmp formated images.",


### PR DESCRIPTION
#### Description
This PR introduces a new MIME type for Adobe Digital Negative (DNG) files:
- **`image/x-adobe-dng`** for `.dng` files

The DNG format is a non-proprietary file format developed by Adobe for storing raw image data from digital cameras. It provides photographers and developers with a standardized format for raw images.

#### Details
- **image/x-adobe-dng**  
  - **Extensions**: `.dng`
  - **Description**: A non-proprietary file format for storing camera raw files
  - **Sources**: [Adobe DNG Specification (PDF)](https://paulbourke.net/dataformats/dng/dng_spec_1_6_0_0.pdf)

#### References
The MIME type is based on the official Adobe DNG specification, which details the structure and purpose of the file format.
