### PR TITLE
Add support for Procreate Dreams 

### DIFF
--- a/db.json
+++ b/db.json
@@ -5241,6 +5241,9 @@
     "source": "iana",
     "extensions": ["box"]
   },
+  "application/vnd.procreate.dream": {
+    "extensions": ["drm"]
+  },
   "application/vnd.proteus.magazine": {
     "source": "iana",
     "extensions": ["mgz"]

--- a/db.json
+++ b/db.json
@@ -5241,9 +5241,6 @@
     "source": "iana",
     "extensions": ["box"]
   },
-  "application/vnd.procreate.dream": {
-    "extensions": ["drm"]
-  },
   "application/vnd.proteus.magazine": {
     "source": "iana",
     "extensions": ["mgz"]

--- a/src/custom-types.json
+++ b/src/custom-types.json
@@ -258,6 +258,14 @@
   "application/vnd.ms-xpsdocument": {
     "compressible": false
   },
+  "application/vnd.procreate.dream": {
+    "extensions": ["drm"],
+    "notes": "A proprietary file type for Procreate Dreams",
+    "sources": [
+      "https://help.procreate.com/articles/dxjyml-exporting-movies",
+      "https://help.procreate.com/articles/deaqnd-export-formats#d43a8f399706"
+    ]
+  },
   "application/vnd.oasis.opendocument.graphics": {
     "compressible": false
   },


### PR DESCRIPTION
**Description:** Introduces the MIME type `application/vnd.procreate.dream`, which corresponds to Procreate Dreams project files (`.drm` extension).

**Details:**

- **MIME Type**: `application/vnd.procreate.dream`
- **Extensions**: `.drm`
- **Description**: A proprietary file type used by Procreate Dreams for saving animation project data.
- **Sources**:
  - [Exporting Movies - Procreate Help](https://help.procreate.com/articles/dxjyml-exporting-movies)
  - [Export Formats - Procreate Help](https://help.procreate.com/articles/deaqnd-export-formats#d43a8f399706)
