### PR TITLE
Add support for the FBX file extension

### DIFF
--- a/db.json
+++ b/db.json
@@ -2486,9 +2486,6 @@
     "source": "iana",
     "extensions": ["aep"]
   },
-  "application/vnd.autodesk.fbx": {
-    "extensions": ["fbx"]
-  },
   "application/vnd.autopackage": {
     "source": "iana"
   },

--- a/db.json
+++ b/db.json
@@ -2486,6 +2486,9 @@
     "source": "iana",
     "extensions": ["aep"]
   },
+  "application/vnd.autodesk.fbx": {
+    "extensions": ["fbx"]
+  },
   "application/vnd.autopackage": {
     "source": "iana"
   },

--- a/src/custom-types.json
+++ b/src/custom-types.json
@@ -203,6 +203,13 @@
       "https://developer.apple.com/library/content/documentation/UserExperience/Conceptual/PassKit_PG/DistributingPasses.html"
     ]
   },
+  "application/vnd.autodesk.fbx": {
+    "extensions": ["fbx"],
+    "sources": [
+      "https://code.blender.org/2013/08/fbx-binary-file-format-specification/"
+    ],
+    "notes": "one of the main 3D exchange formats as used by many 3D tools"
+  },
   "application/vnd.dart": {
     "compressible": true
   },


### PR DESCRIPTION
**Summary**:  
This PR adds the Autodesk FBX file type, a widely used format for 3D models and animations. The format is commonly used for exchanging 3D geometry and animation data across various software platforms.

**Added MIME Type**:
- `application/vnd.autodesk.fbx`

**Details**:
- **Extensions**: `fbx`
- **Notes**: FBX is one of the main 3D exchange formats used by many 3D tools.
- **Sources**:
  - [Blender Code - FBX Binary File Format Specification](https://code.blender.org/2013/08/fbx-binary-file-format-specification/)
