### PR TITLE
Update custom-types.json

### DIFF
--- a/src/custom-types.json
+++ b/src/custom-types.json
@@ -317,6 +317,18 @@
   "application/x-chrome-extension": {
     "extensions": ["crx"]
   },
+  "x-compressed": {
+    "extensions": ["rar"],
+    "notes": "Windows 11 use this mime-type for RAR files instead of application/x-rar-compressed or application/vnd.rar"
+  },
+  "x-zip-compressed": {
+    "extensions": ["zip"],
+    "sources": [
+      "https://bugs.python.org/issue41738",
+      "https://developer.mozilla.org/en-US/docs/Web/HTTP/MIME_types/Common_types"
+    ],
+    "notes": "Windows use this mime-type for Zip files instead of application/zip"
+  },
   "application/x-deb": {
     "compressible": false
   },


### PR DESCRIPTION
Summary:
This PR adds support for compressed types that, despite being deprecated by iana, are still being used by windows.

Added MIME Types:

Mime: application/x-zip-compressed 
Extension: zip
Notes: Windows use this mime-type for Zip files instead of application/zip.
Sources: (https://bugs.python.org/issue41738)
               (https://developer.mozilla.org/en-US/docs/Web/HTTP/MIME_types/Common_types)

application/x-compressed
Extension: rar
Notes: Windows 11 use this mime-type for RAR files instead of application/x-rar-compressed or application/vnd.rar

