### PR TITLE
add dotLottie mime type

### DIFF
--- a/src/custom-types.json
+++ b/src/custom-types.json
@@ -976,5 +976,11 @@
     "sources": [
       "https://github.com/microsoft/referencesource/blob/51cf7850defa8a17d815b4700b67116e3fa283c2/System.Web/MimeMapping.cs#L379"
     ]
+  },
+  "application/zip+dotlottie": {
+    "extensions": ["lottie"],
+    "sources": [
+      "https://dotlottie.io/structure/"
+    ]
   }
 }


### PR DESCRIPTION
dotLottie is an open-source file format that aggregates one or more Lottie files and their associated resources into a single file. They are ZIP archives compressed with the Deflate compression method and carry the file extension of ".lottie". 
more info: https://dotlottie.io/intro/