### PR TITLE
dont throw on 404s when fetching templates from iana

### DIFF
--- a/scripts/fetch-iana.js
+++ b/scripts/fetch-iana.js
@@ -94,7 +94,7 @@ async function addTemplateData (data, options) {
     return
   }
 
-  let res = await got('https://www.iana.org/assignments/media-types/' + data.template)
+  let res = await got(`https://www.iana.org/assignments/media-types/${data.template}`, { throwHttpErrors: false })
   var ref = data.type + '/' + data.name
   var rfc = getRfcReferences(data.reference)[0]
 


### PR DESCRIPTION
workaround for #345

When the update script was refactored to use `got` in 92715b33 it didn't factor in that `got` throws on non success http status codes

So the built in 404 handling in the `addTemplateData` function will never run and we exit early on the unhandled promise rejection.

A workaround is to set [`throwHttpErrors: false`](https://github.com/sindresorhus/got/blob/main/documentation/2-options.md#throwhttperrors) when fetching

```js
let res = await got(url, { throwHttpErrors: false })
```

But the script needs a look over, since the assumptions about the http client's behavior are not valid anymore.

## Why Now?

there were deprecated unofficial (extension) mime types which are 404ing now, `image/x-emf, image/x-wmf` 
I don't see when they went standard as `image/emf, image/wmf`, or when the extension versions started 404ing