### PR TITLE
Add custom type text/x-php 

### DIFF
--- a/src/custom-types.json
+++ b/src/custom-types.json
@@ -905,6 +905,10 @@
       "http://orgmode.org"
     ]
   },
+  "text/x-php": {
+    "compressible": true,
+    "extensions": ["php"]
+  },
   "text/x-processing": {
     "compressible": true,
     "extensions": ["pde"],


### PR DESCRIPTION
Add support for `text/x-php` since `file` command use `text/x-php` in debian system


ref: https://cweiske.de/tagebuch/php-mimetype.htm#linux