### PR TITLE
Fix typo in application/x-zip-compressed mimetype

### DIFF
--- a/src/custom-types.json
+++ b/src/custom-types.json
@@ -317,7 +317,7 @@
   "application/x-chrome-extension": {
     "extensions": ["crx"]
   },
-  "x-compressed": {
+  "application/x-compressed": {
     "extensions": ["rar"],
     "notes": "Windows 11 use this mime-type for RAR files instead of application/x-rar-compressed or application/vnd.rar"
   },

--- a/src/custom-types.json
+++ b/src/custom-types.json
@@ -321,7 +321,7 @@
     "extensions": ["rar"],
     "notes": "Windows 11 use this mime-type for RAR files instead of application/x-rar-compressed or application/vnd.rar"
   },
-  "x-zip-compressed": {
+  "application/x-zip-compressed": {
     "extensions": ["zip"],
     "sources": [
       "https://bugs.python.org/issue41738",


### PR DESCRIPTION
## Summary
#346 added custom mime types for the `.zip` extension. However, at least one of them, `application/x-zip-compressed`, was missing the `application/` prefix. This change simply adds it.

I can't find anything for the other type added by #346, `application/x-compressed` so I didn't make any changes. I question whether that change should have been accepted in the first place without a source. At any rate, @pedro-php (original author) and @wesleytodd (original reviewer) please take a look and confirm whether that one should have the `application/` prefix as well.

The sources for this change are the same as in the original PR. They both include the `application/` prefix:
- https://bugs.python.org/issue41738
- https://developer.mozilla.org/en-US/docs/Web/HTTP/MIME_types/Common_types