### PR TITLE
fix: compressible was set in the wrong file in #163

### DIFF
--- a/src/custom-types.json
+++ b/src/custom-types.json
@@ -127,7 +127,7 @@
     ]
   },
   "application/octet-stream": {
-    "compressible": false,
+    "compressible": true,
     "extensions": ["buffer"],
     "sources": [
       "https://github.com/broofa/node-mime/blob/v1.2.11/types/mime.types#L154"


### PR DESCRIPTION
This fixes the fact that we missed that `compressible` was being changed in the generated file *not* the correct place. 