### PR TITLE
Add support for mhtml and mht (fix #320)

### DIFF
--- a/src/custom-types.json
+++ b/src/custom-types.json
@@ -551,6 +551,14 @@
   "application/x-lua-bytecode": {
     "extensions": ["luac"]
   },
+  "application/x-mimearchive": {
+    "compressible": true,
+    "extensions": ["mht", "mhtml"],
+    "notes": "Web archive file format used to combine HTML code and its companion resources in a single computer file",
+    "sources": [
+      "https://en.wikipedia.org/wiki/MHTML"
+    ]
+  },
   "application/x-mpegurl": {
     "compressible": false
   },


### PR DESCRIPTION
**Summary:**
This PR adds .mhtml and .mht file types, a format used by browser to combine HTML content and assets into one file.

**Added MIME Type:**

 - `application/x-mimearchive`

Details:

**Extensions**: .mht, .mhtml
**Notes**: Web archive file format used to combine HTML code and its companion resources in a single computer file.
**Sources**: [https://en.wikipedia.org/wiki/MHTML](https://en.wikipedia.org/wiki/MHTML)