### PR TITLE
Add extensions for Matroska MIME Types

### DIFF
--- a/src/iana-types.json
+++ b/src/iana-types.json
@@ -9063,6 +9063,7 @@
     ]
   },
   "audio/matroska": {
+    "extensions": ["mka"],
     "sources": [
       "https://tools.ietf.org/rfc/rfc9559.txt",
       "https://www.iana.org/assignments/media-types/audio/matroska"
@@ -11230,12 +11231,14 @@
     ]
   },
   "video/matroska": {
+    "extensions": ["mkv"],
     "sources": [
       "https://tools.ietf.org/rfc/rfc9559.txt",
       "https://www.iana.org/assignments/media-types/video/matroska"
     ]
   },
   "video/matroska-3d": {
+    "extensions": ["mk3d"],
     "sources": [
       "https://tools.ietf.org/rfc/rfc9559.txt",
       "https://www.iana.org/assignments/media-types/video/matroska-3d"


### PR DESCRIPTION
This PR defines the extensions for the Matroska container format mime type.

There are four extensions, albeit only three of them are defined within here in compliance with the IANA assignment in [RFC9559](https://tools.ietf.org/rfc/rfc9559.txt):

- `mka` is for audio and is assigned `audio/matroska`;
- `mkv` is for video and is assigned `video/matroska`;
- `mk3d` is for stereoscopic video and is assigned `video/matroska-3d`; and finally
- `mks` is for subtitles, albeit instead of using the previously (and now deprecated) `video/x-matroska` mime type it is now recommended to to use `application/octet-stream` given that `mks` is in fact not a video. Despite this, I have opted intentionally not to include `mks` as an extension of `application/octet-stream` due to its broad (fallback) scope. 