### PR TITLE
Add `.flac` extension mapping for `audio/flac` MIME type

### DIFF
--- a/db.json
+++ b/db.json
@@ -7255,7 +7255,8 @@
     "source": "iana"
   },
   "audio/flac": {
-    "source": "iana"
+    "source": "iana",
+    "extensions": ["flac"]
   },
   "audio/flexfec": {
     "source": "iana"

--- a/src/iana-types.json
+++ b/src/iana-types.json
@@ -8999,6 +8999,7 @@
     ]
   },
   "audio/flac": {
+    "extensions": ["flac"],
     "sources": [
       "https://tools.ietf.org/rfc/rfc9639.txt",
       "https://www.iana.org/assignments/media-types/audio/flac"


### PR DESCRIPTION
## Description
This PR updates the MIME type definitions to include the `.flac` file extension for `audio/flac`.

## Rationale
The `audio/flac` MIME type was missing its common `.flac` extension, which could lead to incorrect or incomplete content-type resolution when handling FLAC audio files.  
This update ensures consistent mapping and aligns with the [IANA registration](https://www.iana.org/assignments/media-types/audio/flac).

---

Fixes #369 
