### PR TITLE
feat: add apache parquet

### DIFF
--- a/src/custom-types.json
+++ b/src/custom-types.json
@@ -196,6 +196,13 @@
   "application/vnd.android.package-archive": {
     "compressible": false
   },
+  "application/vnd.apache.parquet": {
+    "compressible": false,
+    "extensions": ["parquet"],
+    "sources": [
+      "https://www.iana.org/assignments/media-types/application/vnd.apache.parquet"
+    ]
+  },
   "application/vnd.apple.pkpass": {
     "compressible": false,
     "extensions": ["pkpass"],


### PR DESCRIPTION
## Description

This PR updates the MIME type definitions for Apache Parquet to mark it incompressible, with a `.parquet` file extension.

## Rationale

GitHub pages has been serving them compressed, which [breaks when combined with Range queries](https://github.com/orgs/community/discussions/178318), so mark them uncompressible.

Apache Parquet files are also [usually compressed](https://parquet.apache.org/docs/file-format/data-pages/compression/) already, so it is a sensible choice outside of that bug

Related to #397 and #398
