### PR TITLE
fix: typo in the procreate mime type

### DIFF
--- a/db.json
+++ b/db.json
@@ -5523,7 +5523,7 @@
     "source": "iana",
     "extensions": ["box"]
   },
-  "application/vnd.procrate.brushset": {
+  "application/vnd.procreate.brushset": {
     "extensions": ["brushset"]
   },
   "application/vnd.procreate.brush": {

--- a/src/custom-types.json
+++ b/src/custom-types.json
@@ -398,7 +398,7 @@
     ],
     "notes": "Procreate Brush"
   },
-  "application/vnd.procrate.brushset": {
+  "application/vnd.procreate.brushset": {
     "extensions": ["brushset"],
     "sources": [
       "https://help.procreate.com/procreate/handbook/brushes/brushes-share"


### PR DESCRIPTION
### Description
This PR fixes the MIME type for `.brushset` files

In my previous [PR](https://github.com/jshttp/mime-db/pull/339) I misspelled `application/vnd.procreate.brushset` as `application/vnd.procrate.brushset` this fixes that mistake.
  
- **application/vnd.procreate.brushset**  
  - **Extensions**: `.brushset`
  - **Description**: Procreate Brush Set
  - **Sources**: [Procreate Handbook - Brush Sharing](https://help.procreate.com/procreate/handbook/brushes/brushes-share)

#### Note
- I included the change to db.json because the tests failed without it.
