### PR TITLE
Mark PMTiles as compressible: false

### DIFF
--- a/src/custom-types.json
+++ b/src/custom-types.json
@@ -203,6 +203,13 @@
       "https://www.iana.org/assignments/media-types/application/vnd.apache.parquet"
     ]
   },
+  "application/vnd.pmtiles": {
+    "compressible": false,
+    "extensions": ["pmtiles"],
+    "sources": [
+      "https://www.iana.org/assignments/media-types/application/vnd.pmtiles"
+    ]
+  },
   "application/vnd.apple.pkpass": {
     "compressible": false,
     "extensions": ["pkpass"],


### PR DESCRIPTION
Because this format is used with range requests, marking it as non-compressible is important. See other formats like cloud optimized geotiff or [parquet](https://github.com/jshttp/mime-db/pull/411) with similar use cases.