### PR TITLE
feat: add video/x-flc with flc extension

### DIFF
--- a/src/custom-types.json
+++ b/src/custom-types.json
@@ -1162,6 +1162,10 @@
   "video/webm": {
     "compressible": false
   },
+  "video/x-flc": {
+    "compressible": false,
+    "extensions": ["flc"]
+  },
   "video/x-flv": {
     "compressible": false
   },


### PR DESCRIPTION
Closes #387.

The database has `video/x-fli` (extension `fli`, from Apache) but is missing its FLIC sibling `video/x-flc` (extension `flc`). I verified `flc` is absent from `db.json`, `src/apache-types.json`, and `src/iana-types.json`.

Because `flc` is **not** present in Apache's `mime.types` (only `x-fli` is) and there's no IANA registration, it can't come from the auto-synced source files — so it's added to `src/custom-types.json` (the same place new/non-upstream types live, e.g. the recently merged `application/vnd.apache.parquet`):

```json
  "video/x-flc": {
    "compressible": false,
    "extensions": ["flc"]
  },
```

- `compressible: false` matches the neighbouring video types (`video/x-flv`, `video/x-matroska`, etc.).
- `extensions: ["flc"]` is included here because, unlike those siblings, this type has no upstream definition to inherit the extension from.
- Inserted in alphabetical order (between `video/webm` and `video/x-flv`).

Only `src/custom-types.json` is touched; `db.json` is regenerated by the maintainers via `npm run build`, matching how recent custom-type PRs (e.g. #411) were structured.
